### PR TITLE
EASY-1163 add GET for individual bag files

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -113,7 +113,7 @@ class BagStoreServlet extends ScalatraServlet with BagStoreApp {
   }
 
   get("/:uuid/*") {
-    ItemId.fromString(s"${params("uuid")}/${multiParams("splat").head}")
+    ItemId.fromString(s"""${params("uuid")}/${multiParams("splat").head}""")
       .flatMap(_.toFileId)
       .flatMap(toRealLocation)
       .map(path => {
@@ -122,7 +122,7 @@ class BagStoreServlet extends ScalatraServlet with BagStoreApp {
         val name = path.getFileName.toString
         Ok(bytes, Map(
           "Content-Type" -> fileType,
-          "Content-Disposition" -> ("attachment; filename=\"" + name + "\"")
+          "Content-Disposition" -> s"""attachment; filename="$name""""
         ))
       })
       .onError(e => {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -16,8 +16,8 @@
 package nl.knaw.dans.easy.bagstore
 
 import java.io.InputStream
-import java.net.URI
-import java.nio.file.Paths
+import java.net.{ URI, URLConnection }
+import java.nio.file.{ Files, Paths }
 import java.util.UUID
 
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -112,6 +112,25 @@ class BagStoreServlet extends ScalatraServlet with BagStoreApp {
       }
   }
 
+  get("/:uuid/*") {
+    ItemId.fromString(s"${params("uuid")}/${multiParams("splat").head}")
+      .flatMap(_.toFileId)
+      .flatMap(toRealLocation)
+      .map(path => {
+        val bytes = Files.readAllBytes(path)
+        val fileType = Option(URLConnection.getFileNameMap.getContentTypeFor(path.toString)).getOrElse("application/octet-stream")
+        val name = path.getFileName.toString
+        Ok(bytes, Map(
+          "Content-Type" -> fileType,
+          "Content-Disposition" -> ("attachment; filename=\"" + name + "\"")
+        ))
+      })
+      .onError(e => {
+        logger.error("error in file getter", e)
+        BadRequest(e)
+      })
+  }
+
   // TODO: implement content-negatiation: text/plain for enumFiles, application/zip for zipped bag
 
   put("/:uuid") {
@@ -133,7 +152,7 @@ class BagStoreServlet extends ScalatraServlet with BagStoreApp {
 
   private def putBag(is: InputStream, uuidStr: String): Try[BagId] = {
     for {
-      uuid <- getUuidFromString(params("uuid"))
+      uuid <- getUuidFromString(uuidStr)
       _ <- checkBagDoesNotExist(BagId(uuid))
       staged <- stageBagZip(request.getInputStream)
       bagId <- add(staged, Some(uuid), skipStage = true)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -126,7 +126,7 @@ class BagStoreServlet extends ScalatraServlet with BagStoreApp {
         ))
       })
       .onError(e => {
-        logger.error("error in file getter", e)
+        logger.error("could not retrieve the requested file.", e)
         BadRequest(e)
       })
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -37,7 +37,7 @@ object ItemId {
     s.split("/", 2) match {
       case Array(uuidStr) => BagId(UUID.fromString(uuidStr))
       case Array(uuidStr, path) =>
-        FileId(BagId(UUID.fromString(uuidStr)), Paths.get(URLDecoder.decode(path, "UTF-8")))
+        FileId(UUID.fromString(uuidStr), Paths.get(URLDecoder.decode(path, "UTF-8")))
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-1163

#### When applied it will...
* add a GET to the servlet for individual bag files

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
1. Start the service and make sure the bagstore contains at least one bag.
2. run `curl  http://localhost:8070/<bag-uuid>/<path/to/file>`
3. you get the file contents of the requested file