### PR TITLE
debug improvement

### DIFF
--- a/debug-reset-apphome.sh
+++ b/debug-reset-apphome.sh
@@ -26,7 +26,8 @@ if [ -e $TEMPDIR ]; then
     mv $TEMPDIR $TEMPDIR-`date  +"%Y-%m-%d@%H:%M:%S"`
 fi
 
-mkdir -p $TEMPDIR/bag-store
+mkdir -p $TEMPDIR
+cp -r src/test/resources/debug-resources/* $TEMPDIR
 chmod -R 777 $TEMPDIR
 
 echo "A fresh application home directory for debugging has been set up at $APPHOME"

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreApp.scala
@@ -36,7 +36,7 @@ trait BagStoreApp extends BagStoreContext
   with BagStoreOutputContext
   with DebugEnhancedLogging {
 
-  val properties = new PropertiesConfiguration(new File(new File(System.getProperty("app.home")), "cfg/application.properties"))
+  val properties = new PropertiesConfiguration(new File(System.getProperty("app.home"), "cfg/application.properties"))
   val baseDir: Path = Paths.get(properties.getString("bag-store.base-dir")).toAbsolutePath
   val baseUri = new URI(properties.getString("bag-store.base-uri"))
   val stagingBaseDir: Path = Paths.get(properties.getString("staging.base-dir"))

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/bag-info.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/bag-info.txt
@@ -1,0 +1,3 @@
+Payload-Oxum: 72.6
+Bagging-Date: 2016-06-07
+Bag-Size: 0.6 KB

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/bagit.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/manifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/manifest-md5.txt
@@ -1,0 +1,6 @@
+633039a0d3817e5fa2bd0e7aa89e2e27  data/sub/v
+4377fdf3a848177e41cbd9316f2172f2  data/x
+a7849536df2c23380bd0997b737db506  data/sub/u
+f17a8c16d88784eb3853dc4ae6633ad2  data/sub/w
+83bcb3dcc9006d791f82ce04d1e00b2d  data/z
+b2fa761d13ce7dcb0f3738a4dcbfd9e8  data/y

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/tagmanifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000001/bag-revision-1/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+b4bd0f5f966974b1ad8ac771d6aa00c5  bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
+150581a219338cf76da9f2495cfeade2  manifest-md5.txt

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/bagit.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/fetch.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/fetch.txt
@@ -1,0 +1,4 @@
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/sub/u  12  data/sub/u
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/sub/v  12  data/v
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/y  12  data/y-old
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/x  12  data/x

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/manifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/manifest-md5.txt
@@ -1,0 +1,5 @@
+a7849536df2c23380bd0997b737db506  data/sub/u
+4377fdf3a848177e41cbd9316f2172f2  data/x
+0bc204d0474463beb1a116fc67b0c53f  data/y
+633039a0d3817e5fa2bd0e7aa89e2e27  data/v
+b2fa761d13ce7dcb0f3738a4dcbfd9e8  data/y-old

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/tagmanifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000002/bag-revision-2/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
+a1b0bb98a40cc6a2df21d5c7610a4e65  fetch.txt
+b0064c1b2a22bb1ffafea7a587e2b0c1  manifest-md5.txt

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/bagit.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/fetch.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/fetch.txt
@@ -1,0 +1,7 @@
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/z  12  data/z
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/sub/w  12  data/sub/w
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/y  12  data/y-old
+http://example-archive.org/00000000-0000-0000-0000-000000000002/data/x  12  data/x
+http://example-archive.org/00000000-0000-0000-0000-000000000001/data/sub/u  12  data/sub-copy/u
+http://example-archive.org/00000000-0000-0000-0000-000000000002/data/y  24  data/y
+

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/manifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/manifest-md5.txt
@@ -1,0 +1,8 @@
+f17a8c16d88784eb3853dc4ae6633ad2  data/sub/w
+4377fdf3a848177e41cbd9316f2172f2  data/x
+83bcb3dcc9006d791f82ce04d1e00b2d  data/z
+0bc204d0474463beb1a116fc67b0c53f  data/y
+b2fa761d13ce7dcb0f3738a4dcbfd9e8  data/y-old
+a7849536df2c23380bd0997b737db506  data/sub-copy/u
+a2d461a2feb3c414a1d0152be8c69e33  data/p
+6266ed8807da0878dd1e17940ab899e2  data/sub/q

--- a/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/tagmanifest-md5.txt
+++ b/src/test/resources/debug-resources/bag-store/00/000000000000000000000000000003/bag-revision-3/tagmanifest-md5.txt
@@ -1,0 +1,3 @@
+c70c02f8a973c42506a0ff8a281ab995  fetch.txt
+17c875d4f111b9818b7ccf3715607171  manifest-md5.txt
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt


### PR DESCRIPTION
@janvanmansum 

introduce a resources folder for the debug phase. This folder is located in `src/test/resources/debug-resources`. This can be seen as some kind of a provisioning folder for the `data` folder that is created for local debugging/testing. After the `data` folder is created, the contents of this `debug-resources` folder is copied to the `data` folder.

In the instance of easy-bag-store, I have included an example bag-store with three bags in it, as well as an empty log file. The latter is useful because you want to start tailing the log before starting the service for the first time. Before, this log file was created when the service started for the first time.