### PR TITLE
service and servlet both read the configuration; only needs to be done once

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreApp.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreApp.scala
@@ -45,7 +45,9 @@ trait BagStoreApp extends BagStoreContext
   val outputBagPermissions: String = properties.getString("output.bag-file-permissions")
   val bagFacade = new Bagit4Facade()
 
-  protected def validateSettings(): Unit =  {
+  logger.info("configurations read")
+
+  def validateSettings(): Unit =  {
     assert(Files.isWritable(baseDir), s"Non-existent or non-writable base-dir: $baseDir")
     assert(Files.isWritable(stagingBaseDir), s"Non-existent or non-writable staging base-dir: $stagingBaseDir")
     assert(uuidPathComponentSizes.sum == 32, s"UUID-path component sizes must add up to length of UUID in hexadecimal, sum found: ${uuidPathComponentSizes.sum}")
@@ -54,3 +56,4 @@ trait BagStoreApp extends BagStoreContext
   }
 }
 
+object SingletonBagStoreApp extends BagStoreApp

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
@@ -57,7 +57,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param path the path for which to construct an item-id
    * @return the item-id
    */
-  protected def fromLocation(path: Path): Try[ItemId] = {
+  def fromLocation(path: Path): Try[ItemId] = {
     Try {
       val p = baseDir.relativize(path.toAbsolutePath)
       val nameCount = p.getNameCount
@@ -88,7 +88,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param uri the item-uri
    * @return the item-id
    */
-  protected def fromUri(uri: URI): Try[ItemId] = {
+  def fromUri(uri: URI): Try[ItemId] = {
     object UriComponents {
       def unapply(uri: URI): Option[(String, String, String, Int, Path, String, String)] = Some((
         uri.getScheme,
@@ -153,7 +153,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param id the item-id
    * @return the item-location
    */
-  protected def toLocation(id: ItemId): Try[Path] = {
+  def toLocation(id: ItemId): Try[Path] = {
     for {
       container <- toContainer(id)
       path <- Try {
@@ -174,7 +174,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    *
    * @param fileId
    */
-  protected def toRealLocation(fileId: FileId): Try[Path] = {
+  def toRealLocation(fileId: FileId): Try[Path] = {
     for {
       path <- toLocation(fileId)
       realPath <- if (Files.exists(path)) Try(path)
@@ -197,7 +197,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param id the item-id
    * @return the item-uri
    */
-  protected def toUri(id: ItemId): URI = baseUri.resolve("/" + id.toString)
+  def toUri(id: ItemId): URI = baseUri.resolve("/" + id.toString)
 
   /**
    * Utility function that copies a directory to a staging area. This is used to stage bag directories for
@@ -206,7 +206,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param dir the directory to stage
    * @return the location of the staged directory
    */
-  protected def stageBagDir(dir: Path): Try[Path] = Try {
+  def stageBagDir(dir: Path): Try[Path] = Try {
     trace(dir)
     val staged = Files.createTempFile(stagingBaseDir, "staged-bag-", "")
     Files.deleteIfExists(staged)
@@ -215,7 +215,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     staged
   }
 
-  protected def stageBagZip(is: InputStream): Try[Path] = Try {
+  def stageBagZip(is: InputStream): Try[Path] = Try {
     trace(is)
     val extractDir = Files.createTempFile(stagingBaseDir, "staged-zip-", "")
     Files.deleteIfExists(extractDir)
@@ -234,7 +234,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     else files.head
   }
 
-  protected def mapProjectedToRealLocation(bagDir: Path): Try[Seq[(Path, Path)]] = {
+  def mapProjectedToRealLocation(bagDir: Path): Try[Seq[(Path, Path)]] = {
     for {
       items <- bagFacade.getFetchItems(bagDir)
       mapping <- items.map(item => {
@@ -247,7 +247,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     } yield mapping
   }
 
-  protected def isVirtuallyValid(bagDir: Path): Try[Boolean] =  {
+  def isVirtuallyValid(bagDir: Path): Try[Boolean] =  {
     def getExtraDirectories(links: Seq[Path]): Try[Seq[Path]] = Try {
       val dirs = for {
         link <- links
@@ -329,11 +329,11 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     assert(uuidPath.asScala.map(_.toString.length) == uuidPathComponentSizes, "UUID-part slashed incorrectly")
   }
 
-  protected def formatUuidStrCanonically(s: String): String = {
+  def formatUuidStrCanonically(s: String): String = {
     List(s.slice(0, 8), s.slice(8, 12), s.slice(12, 16), s.slice(16, 20), s.slice(20, 32)).mkString("-")
   }
 
-  protected def checkBagExists(bagId: BagId): Try[Unit] = {
+  def checkBagExists(bagId: BagId): Try[Unit] = {
     toContainer(bagId).flatMap {
       /*
        * If the container exists, the Bag must exist. This function does not check for corruption of the BagStore.
@@ -343,18 +343,18 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     }
   }
 
-  protected def checkBagDoesNotExist(bagId: BagId): Try[Unit] = {
+  def checkBagDoesNotExist(bagId: BagId): Try[Unit] = {
     toContainer(bagId).flatMap {
       case f if Files.exists(f) && Files.isDirectory(f) => Failure(BagIdAlreadyAssignedException(bagId))
       case _ => Success(())
     }
   }
 
-  protected def isHidden(bagId: BagId): Try[Boolean] = {
+  def isHidden(bagId: BagId): Try[Boolean] = {
     toLocation(bagId).map(Files.isHidden)
   }
 
-  protected def setPermissions(permissions: String)(bagDir: Path): Try[Unit] = Try {
+  def setPermissions(permissions: String)(bagDir: Path): Try[Unit] = Try {
     Files.walk(bagDir).iterator().asScala.foreach {
       f => Files.setPosixFilePermissions(f, PosixFilePermissions.fromString(permissions))
     }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -30,8 +30,11 @@ import org.scalatra.servlet.ScalatraListener
 
 import scala.util.Try
 
-class BagStoreService extends BagStoreApp {
+class BagStoreService extends DebugEnhancedLogging {
   import logger._
+  
+  val app = SingletonBagStoreApp
+  import app._
 
   info(s"base directory: $baseDir")
   info(s"base URI: $baseUri")
@@ -85,7 +88,10 @@ object BagStoreService extends App with DebugEnhancedLogging {
   info("Service started ...")
 }
 
-class BagStoreServlet extends ScalatraServlet with BagStoreApp {
+class BagStoreServlet extends ScalatraServlet with DebugEnhancedLogging {
+  val app = SingletonBagStoreApp
+  import app._
+
   val externalBaseUri = new URI(properties.getString("daemon.external-base-uri"))
 
   get("/") {


### PR DESCRIPTION
I noticed that the configurations were read twice when starting the service: once by the service and once by the servlet. This isn't a problem yet, but if in similar style a database connection is opened, you unintentionally end up with two connections while you only require one!

The solution for now is to make a singleton instance of the `BagStoreApp` trait and import this singleton in both the service and servlet.

