### PR TITLE
Minimal solution

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -15,12 +15,15 @@
  */
 import javax.servlet.ServletContext
 
-import nl.knaw.dans.easy.bagstore.BagStoreServlet
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.LifeCycle
 
 class ScalatraBootstrap extends LifeCycle with DebugEnhancedLogging {
   override def init(context: ServletContext) {
-    context.mount(new BagStoreServlet, "/")
+    import nl.knaw.dans.easy.bagstore._
+    context.getAttribute(CONTEXT_ATTRIBUTE_KEY_BAGSTORE_APP) match {
+      case app: BagStoreApp => context.mount(BagStoreServlet(app), "/")
+      case _ => throw new IllegalStateException("Service not configured: no BagStore application found")
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
@@ -174,7 +174,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    *
    * @param fileId
    */
-  protected def toRealLocation(fileId: FileId): Try[Path] = {
+  def toRealLocation(fileId: FileId): Try[Path] = {
     for {
       path <- toLocation(fileId)
       realPath <- if (Files.exists(path)) Try(path)
@@ -197,7 +197,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
    * @param id the item-id
    * @return the item-uri
    */
-  protected def toUri(id: ItemId): URI = baseUri.resolve("/" + id.toString)
+  def toUri(id: ItemId): URI = baseUri.resolve("/" + id.toString)
 
   /**
    * Utility function that copies a directory to a staging area. This is used to stage bag directories for
@@ -215,7 +215,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     staged
   }
 
-  protected def stageBagZip(is: InputStream): Try[Path] = Try {
+  def stageBagZip(is: InputStream): Try[Path] = Try {
     trace(is)
     val extractDir = Files.createTempFile(stagingBaseDir, "staged-zip-", "")
     Files.deleteIfExists(extractDir)
@@ -329,7 +329,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     assert(uuidPath.asScala.map(_.toString.length) == uuidPathComponentSizes, "UUID-part slashed incorrectly")
   }
 
-  protected def formatUuidStrCanonically(s: String): String = {
+  def formatUuidStrCanonically(s: String): String = {
     List(s.slice(0, 8), s.slice(8, 12), s.slice(12, 16), s.slice(16, 20), s.slice(20, 32)).mkString("-")
   }
 
@@ -343,7 +343,7 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     }
   }
 
-  protected def checkBagDoesNotExist(bagId: BagId): Try[Unit] = {
+  def checkBagDoesNotExist(bagId: BagId): Try[Unit] = {
     toContainer(bagId).flatMap {
       case f if Files.exists(f) && Files.isDirectory(f) => Failure(BagIdAlreadyAssignedException(bagId))
       case _ => Success(())

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -42,6 +42,7 @@ class BagStoreService extends BagStoreApp {
   private val port = properties.getInt("daemon.http.port")
   val server = new Server(port)
   val context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
+  context.setAttribute(CONTEXT_ATTRIBUTE_KEY_BAGSTORE_APP, this)
   context.addEventListener(new ScalatraListener())
   server.setHandler(context)
   info(s"HTTP port is $port")
@@ -85,7 +86,8 @@ object BagStoreService extends App with DebugEnhancedLogging {
   info("Service started ...")
 }
 
-class BagStoreServlet extends ScalatraServlet with BagStoreApp {
+case class BagStoreServlet(app: BagStoreApp) extends ScalatraServlet with DebugEnhancedLogging {
+  import app._
   val externalBaseUri = new URI(properties.getString("daemon.external-base-uri"))
 
   get("/") {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -39,6 +39,8 @@ package object bagstore {
   case class NoBagIdException(itemId: ItemId) extends Exception(s"item-id $itemId is not a bag-id")
   case class NoFileIdException(itemId: ItemId) extends Exception(s"item-id $itemId is not a file-id")
 
+  val CONTEXT_ATTRIBUTE_KEY_BAGSTORE_APP = "nl.knaw.dans.easy.bagstore.BagStoreApp"
+
   object Version {
     def apply(): String = {
       val props = new Properties()


### PR DESCRIPTION
NO JIRA-ISSUE: potential problem: when starting as a service, the configuration stap in `nl.knaw.dans.easy.bagstore.BagStoreApp` is executed twice: once when creating an instance of `nl.knaw.dans.easy.bagstore.BagStoreService` and once when creating `nl.knaw.dans.easy.bagstore.BagStoreServlet`.  When configuration means only reading `application.properties` this is not a problem, but it could be when it include acquiring resources.

#### When applied it will...
* Make sure the configuration is only done once, in `nl.knaw.dans.easy.bagstore.BagStoreService`, and then pass this config to the servlet when creating the servlet instance. 

Note that instance fields on a servlet are actually bad practise, as it could result in errors in an environment where servlets are duplicated over JVMs. At the moment we don't worry about that. Our approach is now stand-alone micro-services, so the scenario where a servlet can be duplicated to run in several web containers concurrently is not relevant.

#### Relation to other PRs
Alternative to https://github.com/DANS-KNAW/easy-bag-store/pull/7