### PR TITLE
change implementation

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
@@ -153,9 +153,13 @@ trait Bagit4FacadeComponent extends BagFacadeComponent {
      */
     override def getPayloadFilePaths(bagDir: Path): Try[Set[Path]] =  {
       getBag(bagDir)
-        .map(_.getPayloadManifests.asScala.map(_.asScala.map {
-          case (path, _) => Paths.get(path)
-        }.toSet)).map(_.reduce(_ ++ _))
+        .map(_.getPayloadManifests
+          .asScala
+          .map(_.keySet() // a Manifest extends java.util.Map<String, String>
+            .asScala // converts to mutable set
+            .map(Paths.get(_))
+            .toSet) // make set immutable
+          .reduce(_ ++ _))
     }
   }
 }


### PR DESCRIPTION
@janvanmansum, since you asked for it...

**Explanation:**
* the `getPayloadManifests` returns a collection of `Manifest`s
* a `Manifest` _extends_ `Map<String, String>`, so the path that you're looking for is in the key. Therefore you can just ask for the map's `keySet`. Then the `map` becomes simpler.
* the result of this is a `mutable.Buffer[Set[Path]]`, so you can do the `reduce` immediately; it does not need to be in a separate `Try.map`