### PR TITLE
Making move from staging area to bag-store the final step

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreAdd.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreAdd.scala
@@ -85,8 +85,8 @@ trait BagStoreAdd { this: BagStoreContext with BagStorePrune with BagFacadeCompo
   private def ingest(bagName: Path, staged: Path, container: Path): Try[Unit] = {
     trace(bagName, staged, container)
     val moved = container.resolve(bagName)
-    Try { Files.move(staged, moved) }
-      .flatMap(setPermissions(bagPermissions))
+    setPermissions(bagPermissions)(staged)
+      .map(Files.move(_, moved))
       .map(_ => ())
       .recoverWith {
         case NonFatal(e) =>


### PR DESCRIPTION
Explanation:
=========
Once the bag is in the bag-store it should stay immutable, so any changes to it should be done before it is placed in the bag-store. In the previous version of the code the file permissions were chagned *after* moving. If an exception occurs during this process we would be left with a bag in a possibly corrupted state. That is why I swapped the two operations.


