### PR TITLE
EASY-1254

### DIFF
--- a/run-service.sh
+++ b/run-service.sh
@@ -18,8 +18,8 @@
 
 ARGS=$@
 APPHOME=home
-. apphome.sh
 
+MAVEN_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n" \
 mvn exec:java -Dapp.home=$APPHOME \
               -Dexec.args="run-service" \
               -Dlogback.configurationFile=$APPHOME/cfg/logback-service.xml \

--- a/run.sh
+++ b/run.sh
@@ -18,9 +18,11 @@
 
 ARGS=$@
 APPHOME=home
-. apphome.sh
 
+
+MAVEN_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=y" \
 mvn exec:java -Dapp.home=$APPHOME \
               -Dconfig.file=$APPHOME/cfg/application.conf \
               -Dlogback.configurationFile=$APPHOME/cfg/logback.xml \
               -Dexec.args="$ARGS"
+

--- a/src/main/assembly/dist/bin/easy-bag-store-initd.sh
+++ b/src/main/assembly/dist/bin/easy-bag-store-initd.sh
@@ -27,6 +27,8 @@ WAIT_TIME=60
 jsvc_exec()
 {
     cd ${APPHOME}
+    # Set LC_ALL to a locale with UTF-8 to make sure non-ASCII file names are written correctly to the file system (see: EASY-1254).
+    LC_ALL=en_US.UTF-8 \
     ${EXEC} -home ${JAVA_HOME} -cp ${CLASSPATH} -user ${USER} -outfile ${OUTFILE} -errfile ${ERRFILE} -pidfile ${PID} -wait ${WAIT_TIME} \
           -Dapp.home=${APPHOME} -Dconfig.file=${APPHOME}/cfg/application.conf \
           -Dlogback.configurationFile=${APPHOME}/cfg/logback-service.xml $1 ${CLASS} ${ARGS}

--- a/src/main/assembly/dist/bin/easy-bag-store-service-start
+++ b/src/main/assembly/dist/bin/easy-bag-store-service-start
@@ -3,6 +3,8 @@
 BINPATH=`command readlink -f $0 2> /dev/null || command grealpath $0 2> /dev/null`
 APPHOME=`dirname \`dirname $BINPATH \``
 
+# Set LC_ALL to a locale with UTF-8 to make sure non-ASCII file names are written correctly to the file system (see: EASY-1254).
+LC_ALL=en_US.UTF-8 \
 java -Dlogback.configurationFile=$APPHOME/cfg/logback-service.xml \
      -Dapp.home=$APPHOME \
      -jar $APPHOME/bin/easy-bag-store.jar run-service

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
@@ -225,7 +225,9 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     Files.createDirectory(extractDir)
     val zip = extractDir.resolve("bag.zip")
     FileUtils.copyInputStreamToFile(is, zip.toFile)
-    new ZipFile(zip.toFile).extractAll(extractDir.toAbsolutePath.toString)
+    val zipFile = new ZipFile(zip.toFile)
+    zipFile.setFileNameCharset("UTF-8")
+    zipFile.extractAll(extractDir.toAbsolutePath.toString)
     Files.delete(zip)
     extractDir
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreContext.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.bagstore
 
 import java.io.{IOException, InputStream}
 import java.net.URI
+import java.nio.charset.StandardCharsets
 import java.nio.file._
 import java.nio.file.attribute.{BasicFileAttributes, PosixFilePermissions}
 import java.util.UUID
@@ -225,9 +226,9 @@ trait BagStoreContext { this: BagFacadeComponent with DebugEnhancedLogging =>
     Files.createDirectory(extractDir)
     val zip = extractDir.resolve("bag.zip")
     FileUtils.copyInputStreamToFile(is, zip.toFile)
-    val zipFile = new ZipFile(zip.toFile)
-    zipFile.setFileNameCharset("UTF-8")
-    zipFile.extractAll(extractDir.toAbsolutePath.toString)
+    new ZipFile(zip.toFile) {
+      setFileNameCharset(StandardCharsets.UTF_8.name)
+    }.extractAll(extractDir.toAbsolutePath.toString)
     Files.delete(zip)
     extractDir
   }


### PR DESCRIPTION
Added locale config to service start-up scripts, so that files are read and
written with UTF-8 encoded file names. Added instruction to zip4j to read
UTF-8 file names.

