### PR TITLE
NO JIRA ISSUE: Fixed GET on file item

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagStoreService.scala
@@ -164,7 +164,7 @@ case class BagStoreServlet(app: BagStoreApp) extends ScalatraServlet with DebugE
             itemId: ItemId =>
               debug(s"Retrieving item $itemId")
               app.get(itemId, response.outputStream, base)
-          }.onError {
+          }.map(_ => Ok()).onError {
           case NoSuchBagException(bagId) => NotFound()
           case NonFatal(e) => logger.error("Error retrieving bag", e)
             InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")

--- a/src/test/resources/debug-config/application.properties
+++ b/src/test/resources/debug-config/application.properties
@@ -3,8 +3,8 @@ bag-store.base-uri=http://localhost/
 bag-store.uuid-component-sizes=2,30
 bag-store.bag-file-permissions=r-xr-xr-x
 
-daemon.http.port=8070
-#daemon.ajp.port=8071
-daemon.external-base-uri=http://localhost:8070/
+daemon.http.port=20110
+#daemon.ajp.port=20111
+daemon.external-base-uri=http://localhost:20110/
 staging.base-dir=data/
 output.bag-file-permissions=rwxrwxr-x


### PR DESCRIPTION
- The GET handler for a file item contained a bug that caused Jetty to throw a 500 error
- Updated the debug-config

About the first fix: the error was:
`Error Processing URI: /stores/test/bags/a4546509-59b9-4047-841b-b6df3fd7105a/ - (java.lang.IllegalStateException) STREAM`

http://stackoverflow.com/a/25892426 gives a good explanation for this type of error. In this case it turned out to be because the route `get("/stores/:bagstore/bags/:uuid/*")` in `BagStoreServlet` had return type `Object`. The resulted in `org.scalatra.ScalatraBase#renderPipeline` to select its last `case` which calls `ServletResponse.write` and, of course, we had already retrieved the `ServletResponse`'s `OutputStream` in order to write the file data to the response entity. The solution is to harmonize the returned types from both exit points.