### PR TITLE
PR33-comment: shell script should abort on error

### DIFF
--- a/debug-init-env.sh
+++ b/debug-init-env.sh
@@ -15,7 +15,13 @@
 # limitations under the License.
 #
 
+set -e # abort when a command fails
+
 DATADIR=data
+if [ -e ${DATADIR} ]; then
+    mv ${DATADIR} ${DATADIR}-$(date  +"%Y-%m-%d@%H:%M:%S")
+fi
+mkdir ${DATADIR}
 
 echo -n "Copying test bag stores to $DATADIR..."
 mkdir -p $DATADIR/bag-store1


### PR DESCRIPTION
fixes https://github.com/DANS-KNAW/easy-archive-bag/pull/33#discussion_r130339328

#### When applied
* debug-init-env aborts on error and moves data to backup
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* run the changed script at least twice, it should move the previous `data` directory a `data-*`
* enforce a problem, for example by making `data` inaccessible, run again. The last echoed line should be an error message, not followed by `OK`

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
