### PR TITLE
EASY-1328: Get a file without providing the specific bag-store

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.bagstore.component
 
-import java.io.InputStream
+import java.io.{InputStream, OutputStream}
 import java.nio.file.{ Files, Path }
 import java.util.UUID
 
@@ -47,6 +47,23 @@ trait BagStoresComponent {
             .map(_.get(itemId, output))
             .find(_.isSuccess)
             .getOrElse(Failure(NoSuchBagException(BagId(itemId.uuid))))
+        }
+    }
+
+    def getStream(itemId: ItemId, output: => OutputStream, fromStore: Option[Path] = None): Try[Unit] = {
+      fromStore
+        .flatMap(baseDir => stores.collectFirst {
+          case (_, store) if store.baseDir == baseDir => store.get(itemId, output)
+        })
+        .getOrElse {
+          stores.values.toStream
+            .map(_.get(itemId, output))
+            .find(_.isSuccess)
+            .getOrElse(
+              itemId match {
+                case id @ BagId(_) => Failure(NoSuchBagException(id))
+                case id @ FileId(_, _) => Failure(NoSuchFileException(id))
+              })
         }
     }
 


### PR DESCRIPTION
Fixes EASY-1328 Needed for PDBS file download

#### When applied it will...
* Provide a way to downloads a single file from a specified bag without knowing the storeid
This is needed for a download service that gets download requetsts without a storeid, only the UUID of the bag and a path to the file.  

#### Where should the reviewer @DANS-KNAW/easy start?
src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala 
Start at the line with get("/:uuid/*")
And 
src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
Start at the line with  def getStream

#### How should this be manually tested?
If you have a bag in a store; for instance bag 00000000-0000-0000-0000-000000000001 in the default store on the development VM (vagrant) from test-data/a.zip. 
You can run curl to get a file, for example 'data/y' .   
curl http://localhost:20110/bags/00000000-0000-0000-0000-000000000001/data/y

This should give the same data as when specifying the storeid like: 
curl http://localhost:20110/stores/default/bags/00000000-0000-0000-0000-000000000001/data/y

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 