### PR TITLE
Remove copying of test data.

### DIFF
--- a/src/main/ansible/conditions.fact
+++ b/src/main/ansible/conditions.fact
@@ -1,7 +1,0 @@
-#!/usr/bin/python
-#
-import os, json
-
-print json.dumps({
-    'test_data_does_not_exist': not os.path.exists('/srv/dans.knaw.nl/bag-store/')
-})

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -42,25 +42,6 @@
     setup: filter=ansible_local
     when: result.changed
 
-  - name: Copy test-data to vm
-    copy:
-      src: ../../test/resources/bags/basic-sequence-unpruned-with-refbags/
-      dest: /home/vagrant/test-data/
-      mode: "0777"
-    when: ansible_local.conditions.test_data_does_not_exist
-
-  - name: Create test-data archive
-    archive:
-      path: "/home/vagrant/test-data/{{ item }}"
-      dest: "/home/vagrant/test-data/{{ item }}.zip"
-      format: zip
-      mode: "0777"
-    with_items:
-        - a
-        - b
-        - c
-    when: ansible_local.conditions.test_data_does_not_exist
-
   - name: Install package
     yum:
       name: dans.knaw.nl-easy-bag-store

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -25,23 +25,6 @@
 - hosts: "test"
   become: yes
   tasks:
-  - name: Ensure /etc/ansible/facts.d exists
-    file:
-      path: /etc/ansible/facts.d
-      recurse: yes
-      state: directory
-
-  - name: Copy facts-scripts to server
-    copy:
-      src: conditions.fact
-      dest: /etc/ansible/facts.d/
-      mode: "u+x"
-    register: result
-
-  - name: Reload ansible_local
-    setup: filter=ansible_local
-    when: result.changed
-
   - name: Install package
     yum:
       name: dans.knaw.nl-easy-bag-store


### PR DESCRIPTION
It is not necessary to have Ansible copy test data from the project to the
VM. The project's root directory is accessible in the VM through /vagrant.

@DANS-KNAW/easy for review.