### PR TITLE
Review on #46

### DIFF
--- a/src/main/ansible/roles/bagit/tasks/main.yml
+++ b/src/main/ansible/roles/bagit/tasks/main.yml
@@ -1,0 +1,56 @@
+#
+# Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Download bagit command line tool
+  get_url:
+    url: "https://github.com/LibraryOfCongress/bagit-java/releases/download/v4.12.3/bagit-v4.12.3.zip"
+    dest: "{{ ansible_user_dir }}"
+    checksum: "sha512:c3b422b2cf0b6bf73f189521e7796406cb98a2e9bf8b40ae82719bd5d3111a31ec91127aed541e38383f029d2c050ca4352d8475ea64214f51076f43cb4b5048"
+
+- name: Install unzip
+  yum:
+    name: unzip
+
+- name: Create a provider dir for gov.loc
+  file:
+    path: "/opt/gov.loc/"
+    state: directory
+
+- name: Unzip to /opt
+  unarchive:
+    src: "{{ ansible_user_dir }}/bagit-v4.12.3.zip"
+    remote_src: yes
+    dest: "/opt/gov.loc/"
+    creates: "/opt/gov.loc/bagit-v4.12.3"
+
+- name: Create directory for bagit logging
+  file:
+    path: "/var/opt/gov.loc/log/bagit"
+    state: directory
+    mode: "0777"
+
+- name: Configure logging for bagit
+  replace:
+    path: "/opt/gov.loc/bagit-v4.12.3/conf/log4j.properties"
+    regexp: 'log4j.appender.R.File=.*$'
+    replace: "log4j.appender.R.File=/var/opt/gov.loc/log/bagit/bagit.log"
+
+
+- name: Put bagit on path
+  file:
+    src: "/opt/gov.loc/bagit-v4.12.3/bin/bagit"
+    dest: "/opt/bin/bagit"
+    state: link

--- a/src/main/ansible/vagrant.yml
+++ b/src/main/ansible/vagrant.yml
@@ -35,43 +35,5 @@
       state: started
       enabled: yes
 
-  - name: Download bagit command line tool
-    get_url:
-      url: "https://github.com/LibraryOfCongress/bagit-java/releases/download/v4.12.3/bagit-v4.12.3.zip"
-      dest: "{{ ansible_user_dir }}"
-      checksum: "sha512:c3b422b2cf0b6bf73f189521e7796406cb98a2e9bf8b40ae82719bd5d3111a31ec91127aed541e38383f029d2c050ca4352d8475ea64214f51076f43cb4b5048"
-
-  - name: Install unzip
-    yum:
-      name: unzip
-
-  - name: Create a provider dir for gov.loc
-    file:
-      path: "/opt/gov.loc/"
-      state: directory
-
-  - name: Unzip to /opt
-    unarchive:
-      src: "{{ ansible_user_dir }}/bagit-v4.12.3.zip"
-      remote_src: yes
-      dest: "/opt/gov.loc/"
-      creates: "/opt/gov.loc/bagit-v4.12.3"
-
-  - name: Create directory for bagit logging
-    file:
-      path: "/var/opt/gov.loc/log/bagit"
-      state: directory
-      mode: "0777"
-
-  - name: Configure logging for bagit
-    replace:
-      path: "/opt/gov.loc/bagit-v4.12.3/conf/log4j.properties"
-      regexp: 'log4j.appender.R.File=.*$'
-      replace: "log4j.appender.R.File=/var/opt/gov.loc/log/bagit/bagit.log"
-
-
-  - name: Put bagit on path
-    file:
-      src: "/opt/gov.loc/bagit-v4.12.3/bin/bagit"
-      dest: "/opt/bin/bagit"
-      state: link
+  - include_role:
+      name: bagit

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
@@ -15,7 +15,6 @@
  */
 package nl.knaw.dans.easy.bagstore
 
-import java.awt.geom.NoninvertibleTransformException
 import java.io.IOException
 import java.net.URI
 import java.nio.file.Path
@@ -62,12 +61,12 @@ trait BagFacadeComponent {
 
     def stop(): Try[Unit] = Try { verifier.close() }
 
-    def isValid(bagDir: Path): Try[(Boolean, String)] = {
+    def isValid(bagDir: Path): Try[Either[String, Unit]] = {
       getBag(bagDir)
         .flatMap(bag => Try { verifier.isValid(bag, false) }
-          .map(_ => (true, ""))
+          .map(_ => Right(()))
           .recover {
-            case NonFatal(e) => (false, e.getMessage)
+            case NonFatal(e) => Left(e.getMessage)
           }
         )
     }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -125,9 +125,8 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
             store.baseDir
         }
       }
-      fileSystem.isVirtuallyValid(cmd.bagDir()).map {
-        case (valid, msg) => s"Done validating. Result: virtually-valid = $valid" + (if (valid) "" else s"; Messages: '$msg'")
-      }
+      fileSystem.isVirtuallyValid(cmd.bagDir())
+        .map(res => s"Done validating. Result: " + res.fold(msg => s"not virtually valid; Messages: '$msg'", _ => "virtually-valid"))
     case Some(_ @ commandLine.runService) => runAsService()
     case _ => Try { s"Unknown command: ${ commandLine.subcommand }" }
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -115,7 +115,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
       for {
         itemId <- ItemId.fromString(cmd.itemId())
         location <- bagStores.locate(itemId, bagStoreBaseDir)
-      } yield s"$location"
+      } yield location.toString
     case Some(cmd @ commandLine.validate) =>
       implicit val base: BagPath = bagStoreBaseDir.getOrElse {
         bagStores.stores.toList match {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
@@ -60,16 +60,16 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
       }
 
       for {
-        (virtuallyValid, _) <- fileSystem.isVirtuallyValid(bagDir)
-        _ = debug(s"input virtually-valid?: $virtuallyValid")
-        if virtuallyValid
+        virtuallyValid <- fileSystem.isVirtuallyValid(bagDir)
+        _ = debug(virtuallyValid.fold(msg => s"input not virtually-valid: $msg", _ => "input virtually-valid"))
+        if virtuallyValid.isRight
         mappings <- fileSystem.projectedToRealLocation(bagDir)
         _ <- copyFiles(mappings)
         _ <- bagFacade.removeFetchTxtFromTagManifests(bagDir)
         _ <- Try { Files.deleteIfExists(bagDir.resolve(bagFacade.FETCH_TXT_FILENAME)) }
-        (valid, _) <- bagFacade.isValid(bagDir)
-        _ = debug(s"result valid?: $valid")
-        if valid
+        valid <- bagFacade.isValid(bagDir)
+        _ = debug(valid.fold(msg => s"result invalid: $msg", _ => s"result valid?: $valid"))
+        if valid.isRight
       } yield ()
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -150,9 +150,8 @@ trait BagStoreComponent {
           path = staging.resolve(bagDir.getFileName)
           maybeRefbags <- bagProcessing.getReferenceBags(path)
           _ = debug(s"refbags tempfile: $maybeRefbags")
-          (valid, msg) <- fileSystem.isVirtuallyValid(path).recover { case _: BagReaderException => (false, "Could not read bag") }
-          _ <- if (valid) Success(())
-               else Failure(InvalidBagException(bagId, msg))
+          valid <- fileSystem.isVirtuallyValid(path).recover { case _: BagReaderException => Left("Could not read bag") }
+          _ <- valid.fold(msg => Failure(InvalidBagException(bagId, msg)), _ => Success(()))
           _ <- maybeRefbags.map(pruneWithReferenceBags(path)).getOrElse(Success(()))
           _ = debug("bag succesfully pruned")
           container <- fileSystem.toContainer(bagId)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -161,9 +161,10 @@ trait BagStoresComponent {
           case (_, store) if store.baseDir == baseDir => store.locate(itemId)
         })
         .getOrElse {
-          stores.values.toStream.map(_.locate(itemId)).find(_.isSuccess).getOrElse(
-            Failure(NoSuchItemException(itemId))
-          )
+          stores.values.toStream
+            .map(_.locate(itemId))
+            .find(_.isSuccess)
+            .getOrElse(Failure(NoSuchItemException(itemId)))
         }
     }
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -232,9 +232,6 @@ trait FileSystemComponent extends DebugEnhancedLogging {
     def isVirtuallyValid(bagDir: Path)(implicit baseDir: BaseDir): Try[Either[String, Unit]] = {
       val fetchTxt = bagDir.resolve(bagFacade.FETCH_TXT_FILENAME)
       if (Files.exists(fetchTxt))
-      /*
-       *
-       */
         for {
           tempDir <- Try { Files.createTempDirectory("virtual-bag-") }
           workBag <- symlinkCopy(bagDir, tempDir.resolve(bagDir.getFileName))

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponentSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponentSpec.scala
@@ -27,21 +27,12 @@ class BagFacadeComponentSpec extends TestSupportFixture with BagFacadeComponent 
 
   "isValid" should "return true when passed a valid bag-dir" in {
     FileUtils.copyDirectory(testResourcesDir.resolve("bags/valid-bag").toFile, testDir.resolve("valid-bag").toFile)
-    val result = bagFacade.isValid(testDir.resolve("valid-bag"))
-    result shouldBe a[Success[_]]
-    inside(result) {
-      case Success((s, _)) => s shouldBe true
-
-    }
+    bagFacade.isValid(testDir.resolve("valid-bag")) should matchPattern { case Success(Right(())) => }
   }
 
   it should "return false when passed a bag-dir that is not valid" in {
     FileUtils.copyDirectory(testResourcesDir.resolve("bags/incomplete-bag").toFile, testDir.resolve("incomplete-bag").toFile)
-    val result = bagFacade.isValid(testDir.resolve("incomplete-bag"))
-    result shouldBe a[Success[_]]
-    inside(result) {
-      case Success((s, _)) => s shouldBe false
-    }
+    bagFacade.isValid(testDir.resolve("incomplete-bag")) should matchPattern { case Success(Left(_)) => }
   }
 
   it should "return a failure when passed a non-existent directory" in {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/FileSystemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/FileSystemSpec.scala
@@ -34,7 +34,7 @@ class FileSystemSpec extends TestSupportFixture
     FileUtils.copyDirectory(Paths.get("src/test/resources/bag-store").toFile, store1.toFile)
   }
 
-  override val fileSystem = new FileSystem {
+  override val fileSystem: FileSystem = new FileSystem {
     override val uuidPathComponentSizes: Seq[Int] = Seq(2, 30)
     override val bagPermissions: String = "rwxr-xr-x"
     override val localBaseUri: URI = new URI("http://example-archive.org")
@@ -236,12 +236,12 @@ class FileSystemSpec extends TestSupportFixture
   "isVirtuallyValid" should "return true for a valid bag" in {
     FileUtils.copyDirectory(Paths.get("src/test/resources/bags/valid-bag").toFile, testDir.resolve("valid-bag").toFile)
 
-    fileSystem.isVirtuallyValid(testDir.resolve("valid-bag")) should matchPattern { case Success((true, _)) => }
+    fileSystem.isVirtuallyValid(testDir.resolve("valid-bag")) should matchPattern { case Success(Right(())) => }
   }
 
   it should "return true for a virtually-valid bag" in {
     FileUtils.copyDirectory(Paths.get("src/test/resources/bags/virtually-valid-bag").toFile, testDir.resolve("virtually-valid-bag").toFile)
 
-    fileSystem.isVirtuallyValid(testDir.resolve("virtually-valid-bag")) should matchPattern { case Success((true, _)) => }
+    fileSystem.isVirtuallyValid(testDir.resolve("virtually-valid-bag")) should matchPattern { case Success(Right(())) => }
   }
 }


### PR DESCRIPTION
Review on #46.

Every change is done in a separate commit.

Most notable change:
* refactoring `(Boolean, String)` to `Either[String, Unit]`. From what I saw, when a validation succeeds `(true, "")` was always returned and when a validation fails, a `(false, some_msg)` was always returned. However, the other valid options (a tuple is a product of types, after all) are never supposed to happen. Therefore you can better use a 'sum type' as it is called, such as `Either`, `Try` or `Option`. For now I went with `Either`, since this is the most clear for now. `Either` has two subclasses: `Left` is usually used for error states, which in this case contains a `String`; and `Right` is usually used for the OK state (just because it's the **_right_** result). In this case the `Boolean` is replaced with the notion of `Right` anyway, so we can just give it type `Unit`. Currently `Either` is best controlled by using its `fold` method, while the usual operators like `map`, `filter` and `flatMap` are hidden in the `Either.right` and `Either.left` views. In Scala 2.12 these operators are introduced on top-level in `Either` itself and are then equivalent to `Either.right`.

@DANS-KNAW/easy for review