### PR TITLE
Provide -m,--move flag to add subcommand to skip staging.

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -53,7 +53,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
     case Some(cmd @ commandLine.add) =>
       val bagUuid = cmd.uuid.toOption.map(UUID.fromString)
       val baseDir = bagStoreBaseDir.getOrElse(promptForStore("Please, select which bag store to add to."))
-      BagStore(baseDir).add(cmd.bag(), bagUuid).map(bagId => s"Added bag with bag-id: $bagId to bag store: $baseDir")
+      BagStore(baseDir).add(cmd.bag(), bagUuid, skipStage = cmd.move()).map(bagId => s"Added bag with bag-id: $bagId to bag store: $baseDir")
     case Some(cmd @ commandLine.get) =>
       for {
         itemId <- ItemId.fromString(cmd.itemId())

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -89,6 +89,8 @@ trait CommandLineOptionsComponent {
       val uuid: ScallopOption[String] = opt(name = "uuid", short = 'u',
         descr = "UUID to use as bag-id for the bag",
         required = false)
+      val move: ScallopOption[Boolean] = opt(name = "move",
+        descr = "move (rather than copy) the bag when adding it to the bag store")
       footer(SUBCOMMAND_SEPARATOR)
     }
     addSubcommand(add)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -198,7 +198,7 @@ trait BagStoreComponent {
           _ <- fileSystem.makePathAndParentsInBagStoreGroupWritable(container)
           _ = debug(s"created container for Bag: $container")
           _ <- ingest(bagDir.getFileName, staging, container)
-          _ = FileUtils.deleteDirectory(staging.toFile)
+          _ = if (!skipStage) FileUtils.deleteDirectory(staging.toFile)
         } yield bagId
       }
     }


### PR DESCRIPTION
When adding a bag from the command line it is also necessary to be able to move rather than copy it, especially when it is very large.

@DANS-KNAW/easy 