### PR TITLE
EASY-1413: upgrade to Scala 2.12

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
       test.vm.provision "ansible" do |ansible|
         ansible.playbook = "src/main/ansible/vagrant.yml"
         ansible.config_file = "src/main/ansible/ansible.cfg"
+        ansible.compatibility_mode = "2.0"
 #        ansible.verbose = "vvvv"
       end
       test.vm.provider "virtualbox" do |vb|

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.63-SNAPSHOT</version>
+        <version>1.64</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-prototype</artifactId>
-        <version>1.62</version>
+        <version>1.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>
@@ -42,25 +42,22 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalamock</groupId>
-            <artifactId>scalamock-scalatest-support_2.11</artifactId>
+            <artifactId>scalamock-scalatest-support_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalatest_2.11</artifactId>
-            <version>2.3.0</version>
-            <scope>test</scope>
+            <artifactId>scalatra-scalatest_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.rogach</groupId>
-            <artifactId>scallop_2.11</artifactId>
+            <artifactId>scallop_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
@@ -78,16 +75,14 @@
         <dependency>
             <groupId>gov.loc</groupId>
             <artifactId>bagit</artifactId>
-            <version>5.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_2.11</artifactId>
+            <artifactId>scala-arm_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
-            <artifactId>dans-scala-lib</artifactId>
-            <version>1.2</version>
+            <artifactId>dans-scala-lib_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -108,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra_2.11</artifactId>
+            <artifactId>scalatra_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -117,7 +112,7 @@
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>
-            <artifactId>scalatra-scalate_2.11</artifactId>
+            <artifactId>scalatra-scalate_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
@@ -127,6 +122,14 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.15</version>
+        </dependency>
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.joda</groupId>
+            <artifactId>joda-convert</artifactId>
         </dependency>
     </dependencies>
     <repositories>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/BagFacadeComponent.scala
@@ -33,6 +33,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.Stream.Empty
 import scala.language.postfixOps
 import scala.util.control.NonFatal
+import nl.knaw.dans.lib.error.TryExtensions
 import scala.util.{ Failure, Success, Try }
 
 sealed abstract class Algorithm(val strength: Int)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -16,7 +16,7 @@
 package nl.knaw.dans.easy.bagstore.command
 
 import nl.knaw.dans.easy.bagstore.service.ServiceWiring
-import nl.knaw.dans.easy.bagstore.{ BaseDir, ItemId, TryExtensions2 }
+import nl.knaw.dans.easy.bagstore.{ BaseDir, ItemId }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -15,10 +15,9 @@
  */
 package nl.knaw.dans.easy.bagstore.command
 
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
-import nl.knaw.dans.easy.bagstore
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
 import nl.knaw.dans.easy.bagstore.{ ArchiveStreamType, ConfigurationComponent }
 import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -16,12 +16,10 @@
 package nl.knaw.dans.easy.bagstore.component
 
 import java.net.URI
-import java.util.{Set => JSet}
 import java.nio.file._
 import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermission }
-import java.util.UUID
-import java.util.function.{ Predicate => JPredicate }
 import java.util.stream.{ Stream => JStream }
+import java.util.{ UUID, Set => JSet }
 
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error._
@@ -53,11 +51,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
      */
     def walkStore(implicit baseDir: BaseDir): JStream[BagPath] = {
       Files.walk(baseDir, uuidPathComponentSizes.size, FileVisitOption.FOLLOW_LINKS)
-        .filter(new JPredicate[Path] {
-          def test(path: Path): Boolean = {
-            baseDir.relativize(path).getNameCount == uuidPathComponentSizes.size
-          }
-        })
+        .filter(baseDir.relativize(_).getNameCount == uuidPathComponentSizes.size)
     }
 
     def fromLocation(path: Path)(implicit baseDir: BaseDir): Try[ItemId] = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -24,8 +24,8 @@ import java.util.{ UUID, Set => JSet }
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import nl.knaw.dans.lib.string._
 import org.apache.commons.io.FileUtils
-import org.apache.commons.lang.StringUtils
 
 import scala.collection.JavaConverters._
 import scala.util.{ Failure, Success, Try }
@@ -116,7 +116,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
         // The path part after the base-uri is basically the item-id, but in a Path object.
         val itemIdPath = if (baseUriPath.toString.nonEmpty) baseUriPath.relativize(path)
                          else path
-        if (StringUtils.isBlank(itemIdPath.toString))
+        if (itemIdPath.toString.isBlank)
           Failure(IncompleteItemUriException("base-uri by itself is not an item-uri"))
         else {
           val uuidStr = formatUuidStrCanonically(itemIdPath.getName(0).toString.filterNot(_ == '-'))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -82,16 +82,6 @@ package object bagstore {
     rec(List((f1, f2)))
   }
 
-  implicit class TryExtensions2[T](val t: Try[T]) extends AnyVal {
-    // TODO candidate for dans-scala-lib
-    def unsafeGetOrThrow: T = {
-      t match {
-        case Success(value) => value
-        case Failure(throwable) => throw throwable
-      }
-    }
-  }
-
   // TODO: canditates for dans-scala-lib?
   def listDirs(dir: Path): Seq[Path] = {
     listFiles(dir).filter(Files.isDirectory(_))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/service/ServiceStarter.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/service/ServiceStarter.scala
@@ -41,7 +41,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case NonFatal(e) => logger.info(s"Service startup failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 
   def stop(): Unit = {
@@ -52,7 +52,7 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case NonFatal(e) => logger.error(s"Service stop failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 
   def destroy(): Unit = {
@@ -61,6 +61,6 @@ class ServiceStarter extends Daemon with DebugEnhancedLogging {
       .doIfFailure {
         case e => logger.error(s"Service destroy failed: ${ e.getMessage }", e)
       }
-      .getOrRecover(throw _)
+      .unsafeGetOrThrow
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/BagitFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/BagitFixture.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.bagstore
 
 import org.scalatest.BeforeAndAfterAll
+import nl.knaw.dans.lib.error.TryExtensions
 
 trait BagitFixture extends BagFacadeComponent with BeforeAndAfterAll {
   this: TestSupportFixture =>


### PR DESCRIPTION
fixes EASY-1413

#### When applied it will
* upgrade the project to use Scala_2.12 as the compiler
* use the `dans-scala-lib` functions
* add `compatibility_mode` to `Vagrantfile`

@DANS-KNAW/easy for review