### PR TITLE
EASY-1626 more logging + EASY-1636 more tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,11 @@
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-bag-lib_2.12</artifactId>
             <version>1.0.0-beta-2</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.github.pathikrit</groupId>
             <artifactId>better-files_2.12</artifactId>
-            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.jsuereth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,16 @@
             <artifactId>bagit</artifactId>
         </dependency>
         <dependency>
+            <groupId>nl.knaw.dans.lib</groupId>
+            <artifactId>dans-bag-lib_2.12</artifactId>
+            <version>1.0.0-beta-2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.pathikrit</groupId>
+            <artifactId>better-files_2.12</artifactId>
+            <version>3.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.jsuereth</groupId>
             <artifactId>scala-arm_2.12</artifactId>
         </dependency>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreAuthenticationSupport.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreAuthenticationSupport.scala
@@ -16,13 +16,15 @@
 package nl.knaw.dans.easy.bagstore.server
 
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.ScalatraBase
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 
-trait BagStoreAuthenticationSupport {
+trait BagStoreAuthenticationSupport extends DebugEnhancedLogging {
   self: ScalatraBase =>
 
   def bagstoreUsername: String
+
   def bagstorePassword: String
 
   private val realm = "easy-bag-store"
@@ -32,17 +34,21 @@ trait BagStoreAuthenticationSupport {
     if (!baReq.providesAuth)
       unauthenticated
     else if (!baReq.isBasicAuth)
-      badRequest
-    else if (!validate(baReq.username, baReq.password))
+           badRequest
+    else if (!validate(baReq.username, baReq.password)) {
+      logger.info("invalid user name password combination")
       unauthenticated
+    }
   }
 
   private def badRequest = {
+    logger.info(s"${ request.getMethod } did not have basic authentication")
     halt(400, "Bad Request")
   }
 
   private def unauthenticated = {
     response.setHeader("WWW-Authenticate", s"""Basic realm="$realm"""")
+    logger.info(s"${ request.getMethod } returned status=401(Unauthenticated); headers=${ response.headers }")
     halt(401, "Unauthenticated")
   }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -30,7 +30,7 @@ trait BagsServletComponent extends DebugEnhancedLogging {
 
   val bagsServlet: BagsServlet
 
-  trait BagsServlet extends ScalatraServlet with ServletUtils with ServletEnhancedLogging {
+  trait BagsServlet extends ScalatraServlet with ServletUtils {
 
     get("/") {
       contentType = "text/plain"

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -30,7 +30,7 @@ trait BagsServletComponent extends DebugEnhancedLogging {
 
   val bagsServlet: BagsServlet
 
-  trait BagsServlet extends ScalatraServlet with ServletUtils {
+  trait BagsServlet extends ScalatraServlet with ServletUtils with ServletEnhancedLogging {
 
     get("/") {
       contentType = "text/plain"

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -16,6 +16,7 @@
 package nl.knaw.dans.easy.bagstore.server
 
 import nl.knaw.dans.easy.bagstore.component.BagStoresComponent
+import nl.knaw.dans.easy.bagstore.server.ServletEnhancedLogging._
 import nl.knaw.dans.easy.bagstore.{ ItemId, NoRegularFileException, NoSuchBagException, NoSuchFileItemException }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
@@ -40,7 +41,7 @@ trait BagsServletComponent extends DebugEnhancedLogging {
         .getOrRecover(e => {
           logger.error("Unexpected type of failure", e)
           InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-        })
+        }).logResponse
     }
 
     get("/:uuid") {
@@ -66,12 +67,12 @@ trait BagsServletComponent extends DebugEnhancedLogging {
           case e =>
             logger.error("Unexpected type of failure", e)
             InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-        }
+        }.logResponse
     }
 
     get("/:uuid/*") {
       val uuidStr = params("uuid")
-      multiParams("splat") match {
+      (multiParams("splat") match {
         case Seq(path) =>
           ItemId.fromString(s"""$uuidStr/${ path }""")
             .recoverWith {
@@ -94,7 +95,7 @@ trait BagsServletComponent extends DebugEnhancedLogging {
         case p =>
           logger.error(s"Unexpected path: $p")
           InternalServerError("Unexpected path")
-      }
+      }).logResponse
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.bagstore.server
 import java.net.URI
 
 import nl.knaw.dans.easy.bagstore.component.BagStoresComponent
+import nl.knaw.dans.easy.bagstore.server.ServletEnhancedLogging._
 import org.scalatra.{ Ok, ScalatraServlet }
 
 trait DefaultServletComponent {
@@ -31,10 +32,11 @@ trait DefaultServletComponent {
 
     get("/") {
       contentType = "text/plain"
-      Ok(s"""EASY Bag Store is running.
+      Ok(
+        s"""EASY Bag Store is running.
            |Available stores at <${ externalBaseUri.resolve("stores") }>
            |Bags from all stores at <${ externalBaseUri.resolve("bags") }>
-           |""".stripMargin)
+           |""".stripMargin).logResponse
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
@@ -25,7 +25,7 @@ trait DefaultServletComponent {
 
   val defaultServlet: DefaultServlet
 
-  trait DefaultServlet extends ScalatraServlet {
+  trait DefaultServlet extends ScalatraServlet with ServletEnhancedLogging {
 
     val externalBaseUri: URI
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -21,7 +21,7 @@ import org.scalatra.{ ActionResult, ScalatraBase }
 
 import scala.util.{ Failure, Success, Try }
 
-// TODO candidate for dans-scala-lib (another package than authentication?)
+// TODO candidate for dans-scala-lib (copied from easy-deposit-api)
 trait ServletEnhancedLogging extends DebugEnhancedLogging {
   this: ScalatraBase =>
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -19,14 +19,19 @@ import javax.servlet.http.HttpServletRequest
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.scalatra.{ ActionResult, ScalatraBase }
 
-// simplified copy of easy-deposit-api
-// hardly a library candidate because filters (personal info) on headers or other details might be required
+// simplified but filtered copy of easy-deposit-api
 
 trait ServletEnhancedLogging extends DebugEnhancedLogging {
   this: ScalatraBase =>
 
   before() {
-    logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
+    val headers = request.headers.map{
+      // TODO a library version should filter any authentication any client might invent and probably provide hooks for more filters
+      // see private val BasicAuthStrategy.AUTHORIZATION_KEYS
+      case(key,value) if key.toLowerCase.endsWith("authorization") => (key,"*****")
+      case keyValue => keyValue
+    }
+    logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=$headers")
   }
 }
 object ServletEnhancedLogging extends DebugEnhancedLogging {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -15,42 +15,14 @@
  */
 package nl.knaw.dans.easy.bagstore.server
 
-import javax.servlet.http.HttpServletRequest
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.scalatra.{ ActionResult, ScalatraBase }
+import org.scalatra.ScalatraBase
 
-import scala.util.{ Failure, Success, Try }
-
-// TODO candidate for dans-scala-lib (copied from easy-deposit-api)
 trait ServletEnhancedLogging extends DebugEnhancedLogging {
   this: ScalatraBase =>
 
+  // copied from easy-deposit-api, in case filters on the headers or other details might be required: no library candidate
   before() {
     logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
-  }
-}
-object ServletEnhancedLogging extends DebugEnhancedLogging {
-
-  implicit class RichActionResult(actionResult: ActionResult)(implicit request: HttpServletRequest) {
-    def logResponse: ActionResult = logResult(actionResult)
-  }
-
-  implicit class RichTriedActionResult(tried: Try[ActionResult])(implicit request: HttpServletRequest) {
-    // TODO to preserve actionResult into and beyond after filters, copy it into "implicit response: HttpServletResponse"
-    // See the last extensive readme version (documentation moved into an incomplete book and guides)
-    // https://github.com/scalatra/scalatra/blob/6a614d17c38d19826467adcabf1dc746e3192dfc/README.markdown
-    // sections #filters #action
-    def getOrRecoverResponse(recover: Throwable => ActionResult): ActionResult = {
-      // the signature is more specific than in nl.knaw.dans.lib.error and comes with the trait, not with just an import
-      logResult(tried match {
-        case Success(actionResult) => actionResult
-        case Failure(throwable) => recover(throwable)
-      })
-    }
-  }
-
-  private def logResult(actionResult: ActionResult)(implicit request: HttpServletRequest) = {
-    logger.info(s"${ request.getMethod } returned status=${ actionResult.status } headers=${ actionResult.headers }")
-    actionResult
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -32,6 +32,12 @@ trait ServletEnhancedLogging extends DebugEnhancedLogging {
 object ServletEnhancedLogging extends DebugEnhancedLogging {
 
   implicit class RichActionResult(actionResult: ActionResult)(implicit request: HttpServletRequest) {
+
+    /**
+     * @example halt(BadRequest().logResponse)
+     * @example Ok().logResponse
+     * @return this
+     */
     def logResponse: ActionResult = {
       logger.info(s"${ request.getMethod } returned status=${ actionResult.status } headers=${ actionResult.headers }")
       actionResult

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -21,7 +21,7 @@ import org.scalatra.ScalatraBase
 trait ServletEnhancedLogging extends DebugEnhancedLogging {
   this: ScalatraBase =>
 
-  // copied from easy-deposit-api, in case filters on the headers or other details might be required: no library candidate
+  // copied from easy-deposit-api, no library candidate because filters on the headers or other details might be required:
   before() {
     logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.bagstore.server
+
+import javax.servlet.http.HttpServletRequest
+import nl.knaw.dans.lib.logging.DebugEnhancedLogging
+import org.scalatra.{ ActionResult, ScalatraBase }
+
+import scala.util.{ Failure, Success, Try }
+
+// TODO candidate for dans-scala-lib (another package than authentication?)
+trait ServletEnhancedLogging extends DebugEnhancedLogging {
+  this: ScalatraBase =>
+
+  before() {
+    logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
+  }
+}
+object ç extends DebugEnhancedLogging {
+
+  implicit class RichActionResult(actionResult: ActionResult)(implicit request: HttpServletRequest) {
+    def logResponse: ActionResult = logResult(actionResult)
+  }
+
+  implicit class RichTriedActionResult(tried: Try[ActionResult])(implicit request: HttpServletRequest) {
+    // TODO to preserve actionResult into and beyond after filters, copy it into "implicit response: HttpServletResponse"
+    // See the last extensive readme version (documentation moved into an incomplete book and guides)
+    // https://github.com/scalatra/scalatra/blob/6a614d17c38d19826467adcabf1dc746e3192dfc/README.markdown
+    // sections #filters #action
+    def getOrRecoverResponse(recover: Throwable => ActionResult): ActionResult = {
+      // the signature is more specific than in nl.knaw.dans.lib.error and comes with the trait, not with just an import
+      logResult(tried match {
+        case Success(actionResult) => actionResult
+        case Failure(throwable) => recover(throwable)
+      })
+    }
+  }
+
+  private def logResult(actionResult: ActionResult)(implicit request: HttpServletRequest) = {
+    logger.info(s"${ request.getMethod } returned status=${ actionResult.status } headers=${ actionResult.headers }")
+    actionResult
+  }
+}

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -29,7 +29,7 @@ trait ServletEnhancedLogging extends DebugEnhancedLogging {
     logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
   }
 }
-object ç extends DebugEnhancedLogging {
+object ServletEnhancedLogging extends DebugEnhancedLogging {
 
   implicit class RichActionResult(actionResult: ActionResult)(implicit request: HttpServletRequest) {
     def logResponse: ActionResult = logResult(actionResult)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -15,14 +15,26 @@
  */
 package nl.knaw.dans.easy.bagstore.server
 
+import javax.servlet.http.HttpServletRequest
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.scalatra.ScalatraBase
+import org.scalatra.{ ActionResult, ScalatraBase }
+
+// simplified copy of easy-deposit-api
+// hardly a library candidate because filters (personal info) on headers or other details might be required
 
 trait ServletEnhancedLogging extends DebugEnhancedLogging {
   this: ScalatraBase =>
 
-  // copied from easy-deposit-api, no library candidate because filters on the headers or other details might be required:
   before() {
     logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=${ request.headers }")
+  }
+}
+object ServletEnhancedLogging extends DebugEnhancedLogging {
+
+  implicit class RichActionResult(actionResult: ActionResult)(implicit request: HttpServletRequest) {
+    def logResponse: ActionResult = {
+      logger.info(s"${ request.getMethod } returned status=${ actionResult.status } headers=${ actionResult.headers }")
+      actionResult
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletUtils.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletUtils.scala
@@ -16,10 +16,13 @@
 package nl.knaw.dans.easy.bagstore.server
 
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType
+import org.scalatra.ScalatraBase
 
 import scala.language.implicitConversions
 
-trait ServletUtils {
+trait ServletUtils extends ServletEnhancedLogging {
+  this: ScalatraBase =>
+
   type IncludeActive = Boolean
   type IncludeInactive = Boolean
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -33,7 +33,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
 
   val storesServlet: StoresServlet
 
-  trait StoresServlet extends ScalatraServlet with ServletUtils with BagStoreAuthenticationSupport with ServletEnhancedLogging {
+  trait StoresServlet extends ScalatraServlet with ServletUtils with BagStoreAuthenticationSupport {
 
     val externalBaseUri: URI
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -33,7 +33,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
 
   val storesServlet: StoresServlet
 
-  trait StoresServlet extends ScalatraServlet with ServletUtils with BagStoreAuthenticationSupport {
+  trait StoresServlet extends ScalatraServlet with ServletUtils with BagStoreAuthenticationSupport with ServletEnhancedLogging {
 
     val externalBaseUri: URI
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.{ BagStoresComponent, FileSystemComponent }
+import nl.knaw.dans.easy.bagstore.server.ServletEnhancedLogging._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.joda.time.DateTime
@@ -42,7 +43,8 @@ trait StoresServletComponent extends DebugEnhancedLogging {
       Ok(bagStores.storeShortnames
         .keys
         .map(store => s"<${ externalBaseUri.resolve(s"stores/$store") }>")
-        .mkString("\n"))
+        .mkString("\n")
+      ).logResponse
     }
 
     get("/:bagstore") {
@@ -55,6 +57,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
              |""".stripMargin
         })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
+        .logResponse
     }
 
     get("/:bagstore/bags") {
@@ -70,6 +73,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
             })
         })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
+        .logResponse
     }
 
     get("/:bagstore/bags/:uuid") {
@@ -103,12 +107,13 @@ trait StoresServletComponent extends DebugEnhancedLogging {
               InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
           })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
+        .logResponse
     }
 
     get("/:bagstore/bags/:uuid/*") {
       val bagstore = params("bagstore")
       val uuidStr = params("uuid")
-      multiParams("splat") match {
+      (multiParams("splat") match {
         case Seq(path) =>
           bagStores.getBaseDirByShortname(bagstore)
             .map(baseDir => ItemId.fromString(s"""$uuidStr/${ path }""")
@@ -134,7 +139,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
         case p =>
           logger.error(s"Unexpected path: $p")
           InternalServerError("Unexpected path")
-      }
+      }).logResponse
     }
 
     put("/:bagstore/bags/:uuid") {
@@ -163,6 +168,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
             }
         })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
+        .logResponse
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/TestSupportFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/TestSupportFixture.scala
@@ -19,8 +19,10 @@ import java.nio.file.{ Files, Path, Paths }
 
 import org.apache.commons.io.FileUtils
 import org.scalatest._
+import org.scalatest.enablers.Existence
 
 trait TestSupportFixture extends FlatSpec with Matchers with Inside {
+  implicit def existenceOfFile[FILE <: better.files.File]: Existence[FILE] = _.exists
   lazy val testDir: Path = {
     val path = Paths.get(s"target/test/${ getClass.getSimpleName }").toAbsolutePath
     FileUtils.deleteQuietly(path.toFile)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingFixture.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingFixture.scala
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.bagstore.component
+
+import java.net.URI
+import java.nio.file.attribute.{ PosixFilePermission, PosixFilePermissions }
+
+import nl.knaw.dans.easy.bagstore._
+
+class BagProcessingFixture extends TestSupportFixture
+  with BagStoreFixture
+  with BagitFixture
+  with BagStoreComponent
+  with BagProcessingComponent
+  with FileSystemComponent {
+
+  override val fileSystem: FileSystem = new FileSystem {
+    override val uuidPathComponentSizes: Seq[Int] = Seq(2, 30)
+    override val bagFilePermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
+    override val bagDirPermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
+    override val localBaseUri: URI = new URI("http://localhost")
+  }
+
+  override val bagProcessing: BagProcessing = new BagProcessing {
+    override val stagingBaseDir: BagPath = testDir
+    override val outputBagFilePermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
+    override val outputBagDirPermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
@@ -18,7 +18,6 @@ package nl.knaw.dans.easy.bagstore.component
 import java.io.FileInputStream
 import java.net.URI
 import java.nio.file.Paths
-import java.nio.file.attribute.{ PosixFilePermission, PosixFilePermissions }
 import java.util.UUID
 
 import nl.knaw.dans.easy.bagstore._
@@ -27,12 +26,7 @@ import org.apache.commons.io.FileUtils
 import scala.io.Source
 import scala.util.{ Failure, Success }
 
-class BagProcessingSpec extends TestSupportFixture
-  with BagStoreFixture
-  with BagitFixture
-  with BagStoreComponent
-  with BagProcessingComponent
-  with FileSystemComponent {
+class BagProcessingSpec extends BagProcessingFixture {
 
   FileUtils.copyDirectory(
     Paths.get("src/test/resources/bags/basic-sequence-pruned").toFile,
@@ -48,20 +42,7 @@ class BagProcessingSpec extends TestSupportFixture
   private val testBagUnprunedB = testDir.resolve("basic-sequence-unpruned/b")
   private val testBagUnprunedC = testDir.resolve("basic-sequence-unpruned/c")
 
-  override val fileSystem = new FileSystem {
-    override val uuidPathComponentSizes: Seq[Int] = Seq(2, 30)
-    override val bagFilePermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
-    override val bagDirPermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
-    override val localBaseUri: URI = new URI("http://localhost")
-  }
-
-  override val bagProcessing = new BagProcessing {
-    override val stagingBaseDir: BagPath = testDir
-    override val outputBagFilePermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
-    override val outputBagDirPermissions: java.util.Set[PosixFilePermission] = PosixFilePermissions.fromString("rwxr-xr-x")
-  }
-
-  private val bagStore = new BagStore {
+  val bagStore: BagStore = new BagStore {
     implicit val baseDir: BaseDir = store1
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2016 DANS - Data Archiving and Networked Services (info@dans.knaw.nl)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.knaw.dans.easy.bagstore.component
+
+import java.util.UUID
+
+import nl.knaw.dans.easy.bagstore.BagId
+
+import scala.util.Failure
+
+class PruneSpec extends BagProcessingFixture {
+
+  "prune" should "report the missing referenced bag" in {
+    val uuid = UUID.randomUUID()
+    bagProcessing.prune(
+      testDir.resolve("bag"), // bag to prune which does not exist
+      Seq(BagId(uuid)) // single referenced bag that doesn't exist
+    )(store1) should matchPattern {
+      case Failure(e)
+        if e.getMessage.contains("NoSuchFileException")
+          && e.getMessage.contains(pathFromUUID(uuid))
+      =>
+    }
+  }
+
+  it should "report all missing referenced bags" in {
+    val uuid1 = UUID.randomUUID()
+    val uuid2 = UUID.randomUUID()
+    bagProcessing.prune(
+      testDir.resolve("bag"), // bag to prune which does not exist
+      Seq(BagId(uuid1), BagId(uuid2)) // multiple referenced bags that don't exist
+    )(store1) should matchPattern {
+      case Failure(e) // TODO "NoSuchFileException" is lost
+        if e.getMessage.contains("START OF EXCEPTION LIST")
+          && e.getMessage.contains(pathFromUUID(uuid1))
+          && e.getMessage.contains(pathFromUUID(uuid2))
+      =>
+    }
+  }
+
+  private def pathFromUUID(randomUUUID: UUID) = {
+    randomUUUID.toString
+      .replaceAll("-", "")
+      .replaceAll("^(..)", "$1/")
+  }
+}

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -41,12 +41,11 @@ class PruneSpec extends BagProcessingFixture {
       .addPayloadFile(toStream("doler"), Paths.get("some.x/some.txt")).getOrRecover(e => fail(e))
       .addPayloadFile(toStream("sit amet"), Paths.get("some.y")).getOrRecover(e => fail(e))
       .save()
-    // File("src/test/resources/XXX").copyTo(File(testDir) / "bag")
 
     bagProcessing.prune(
       testDir.resolve("bag"),
-      Seq(BagId(uuid)) // single referenced bag
-    ) shouldBe Success("xxx")
+      Seq(BagId(uuid))
+    ) shouldBe Success(())
     (bagDir / "data").size shouldBe 2
     (bagDir / "fetch.txt").toJava shouldNot exist // TODO drop toJava with ???
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -47,7 +47,7 @@ class PruneSpec extends BagProcessingFixture {
       Seq(BagId(uuid))
     ) shouldBe Success(())
     (bagDir / "data").list.size shouldBe 2
-    (bagDir / "fetch.txt").toJava shouldNot exist // TODO drop toJava with ???
+    (bagDir / "fetch.txt") shouldNot exist
   }
 
   it should "report an invalid referenced bag" in {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -30,7 +30,7 @@ class PruneSpec extends BagProcessingFixture {
 
   implicit val referencedStore: BagPath = store1
 
-  "prune" should "not prune when a file in one is a folder in the other and vice versa" in pendingUntilFixed {
+  "prune" should "not prune when a file in one is a folder in the other and vice versa" in {
     val uuid = UUID.randomUUID()
     DansV0Bag.empty(File(store1) / pathFromUUID(uuid) / "bag").getOrRecover(e => fail(e))
       .addPayloadFile(toStream("lorum"), Paths.get("some.x")).getOrRecover(e => fail(e))
@@ -46,7 +46,7 @@ class PruneSpec extends BagProcessingFixture {
       testDir.resolve("bag"),
       Seq(BagId(uuid))
     ) shouldBe Success(())
-    (bagDir / "data").size shouldBe 2
+    (bagDir / "data").list.size shouldBe 2
     (bagDir / "fetch.txt").toJava shouldNot exist // TODO drop toJava with ???
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -15,43 +15,85 @@
  */
 package nl.knaw.dans.easy.bagstore.component
 
+import java.io.ByteArrayInputStream
+import java.nio.file.Paths
 import java.util.UUID
 
+import better.files.File
+import nl.knaw.dans.bag.v0.DansV0Bag
 import nl.knaw.dans.easy.bagstore.BagId
+import nl.knaw.dans.lib.error._
 
-import scala.util.Failure
+import scala.util.{ Failure, Success }
 
 class PruneSpec extends BagProcessingFixture {
 
-  "prune" should "report the missing referenced bag" in {
+  implicit val referencedStore: BagPath = store1
+
+  "prune" should "not prune when a file in one is a folder in the other and vice versa" in pendingUntilFixed {
+    val uuid = UUID.randomUUID()
+    DansV0Bag.empty(File(store1) / pathFromUUID(uuid) / "bag").getOrRecover(e => fail(e))
+      .addPayloadFile(toStream("lorum"), Paths.get("some.x")).getOrRecover(e => fail(e))
+      .addPayloadFile(toStream("ipsum"), Paths.get("some.y/test.txt")).getOrRecover(e => fail(e))
+      .save()
+    val bagDir = File(testDir) / "bag"
+    DansV0Bag.empty(bagDir).getOrRecover(e => fail(e))
+      .addPayloadFile(toStream("doler"), Paths.get("some.x/some.txt")).getOrRecover(e => fail(e))
+      .addPayloadFile(toStream("sit amet"), Paths.get("some.y")).getOrRecover(e => fail(e))
+      .save()
+    // File("src/test/resources/XXX").copyTo(File(testDir) / "bag")
+
+    bagProcessing.prune(
+      testDir.resolve("bag"),
+      Seq(BagId(uuid)) // single referenced bag
+    ) shouldBe Success("xxx")
+    (bagDir / "data").size shouldBe 2
+    (bagDir / "fetch.txt").toJava shouldNot exist // TODO drop toJava with ???
+  }
+
+  it should "report an invalid referenced bag" in {
+    val uuid = UUID.randomUUID()
+    (File(store1) / pathFromUUID(uuid) / "bag").createDirectories()
+    bagProcessing.prune(
+      testDir.resolve("bag"), // bag to prune which does not exist
+      Seq(BagId(uuid)) // single referenced bag
+    ) should matchPattern {
+      case Failure(e) if containsFragments(e, Seq("The bag at", pathFromUUID(uuid), "could not be read")) =>
+    }
+  }
+
+  it should "report a missing referenced bag" in {
     val uuid = UUID.randomUUID()
     bagProcessing.prune(
       testDir.resolve("bag"), // bag to prune which does not exist
-      Seq(BagId(uuid)) // single referenced bag that doesn't exist
-    )(store1) should matchPattern {
-      case Failure(e)
-        if e.getMessage.contains("NoSuchFileException")
-          && e.getMessage.contains(pathFromUUID(uuid))
-      =>
+      Seq(BagId(uuid)) // single referenced bag
+    ) should matchPattern {
+      case Failure(e) if containsFragments(e, Seq("NoSuchFileException", pathFromUUID(uuid))) =>
     }
   }
 
   it should "report all missing referenced bags" in {
-    val uuid1 = UUID.randomUUID()
-    val uuid2 = UUID.randomUUID()
+    val referencedBags = (0 until 2).map(_ => BagId(UUID.randomUUID()))
+    val msgFragments = "START OF EXCEPTION LIST" +: referencedBags.map(bagId => pathFromUUID(bagId.uuid))
     bagProcessing.prune(
       testDir.resolve("bag"), // bag to prune which does not exist
-      Seq(BagId(uuid1), BagId(uuid2)) // multiple referenced bags that don't exist
-    )(store1) should matchPattern {
-      case Failure(e) // TODO "NoSuchFileException" is lost
-        if e.getMessage.contains("START OF EXCEPTION LIST")
-          && e.getMessage.contains(pathFromUUID(uuid1))
-          && e.getMessage.contains(pathFromUUID(uuid2))
-      =>
+      referencedBags // they don't exist
+    ) should matchPattern { // TODO "NoSuchFileException" is lost
+      case Failure(e) if containsFragments(e, msgFragments) =>
     }
   }
 
+  // TODO see https://github.com/DANS-KNAW/easy-deposit-api/blob/1f742c812d5a98754b010d32abdc282db5d256c3/src/main/scala/nl.knaw.dans.easy.deposit/package.scala#L73-L77
+  def toStream(s: String) = new ByteArrayInputStream(s.getBytes())
+
+  private def containsFragments(e: Throwable, msgFragments: Seq[String]) = {
+    // TODO implicit class or custom matcher
+    val message = e.getMessage
+    msgFragments.forall(fragment => { message.contains(fragment) })
+  }
+
   private def pathFromUUID(randomUUUID: UUID) = {
+    // TODO this more or less mimics FileSystemComponent.toContainer
     randomUUUID.toString
       .replaceAll("-", "")
       .replaceAll("^(..)", "$1/")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/PruneSpec.scala
@@ -32,14 +32,14 @@ class PruneSpec extends BagProcessingFixture {
 
   "prune" should "not prune when a file in one is a folder in the other and vice versa" in {
     val uuid = UUID.randomUUID()
-    DansV0Bag.empty(File(store1) / pathFromUUID(uuid) / "bag").getOrRecover(e => fail(e))
-      .addPayloadFile(toStream("lorum"), Paths.get("some.x")).getOrRecover(e => fail(e))
-      .addPayloadFile(toStream("ipsum"), Paths.get("some.y/test.txt")).getOrRecover(e => fail(e))
+    DansV0Bag.empty(File(store1) / pathFromUUID(uuid) / "bag").getOrRecover(fail(_))
+      .addPayloadFile(toStream("lorum"), Paths.get("some.x")).getOrRecover(fail(_))
+      .addPayloadFile(toStream("ipsum"), Paths.get("some.y/test.txt")).getOrRecover(fail(_))
       .save()
     val bagDir = File(testDir) / "bag"
-    DansV0Bag.empty(bagDir).getOrRecover(e => fail(e))
-      .addPayloadFile(toStream("doler"), Paths.get("some.x/some.txt")).getOrRecover(e => fail(e))
-      .addPayloadFile(toStream("sit amet"), Paths.get("some.y")).getOrRecover(e => fail(e))
+    DansV0Bag.empty(bagDir).getOrRecover(fail(_))
+      .addPayloadFile(toStream("doler"), Paths.get("some.x/some.txt")).getOrRecover(fail(_))
+      .addPayloadFile(toStream("sit amet"), Paths.get("some.y")).getOrRecover(fail(_))
       .save()
 
     bagProcessing.prune(
@@ -83,15 +83,15 @@ class PruneSpec extends BagProcessingFixture {
   }
 
   // TODO see https://github.com/DANS-KNAW/easy-deposit-api/blob/1f742c812d5a98754b010d32abdc282db5d256c3/src/main/scala/nl.knaw.dans.easy.deposit/package.scala#L73-L77
-  def toStream(s: String) = new ByteArrayInputStream(s.getBytes())
+  def toStream(s: String): ByteArrayInputStream = new ByteArrayInputStream(s.getBytes())
 
-  private def containsFragments(e: Throwable, msgFragments: Seq[String]) = {
+  private def containsFragments(e: Throwable, msgFragments: Seq[String]): Boolean = {
     // TODO implicit class or custom matcher
     val message = e.getMessage
-    msgFragments.forall(fragment => { message.contains(fragment) })
+    msgFragments.forall(message.contains)
   }
 
-  private def pathFromUUID(randomUUUID: UUID) = {
+  private def pathFromUUID(randomUUUID: UUID): String = {
     // TODO this more or less mimics FileSystemComponent.toContainer
     randomUUUID.toString
       .replaceAll("-", "")


### PR DESCRIPTION
Fixes easy-1626 partially

#### When applied it will...
* have more unit tests for pruning
* ~~one test is **pendingUntilFixed**, it demonstrates potential data loss~~
* log requests and responses
  * [x] filter personal info

#### Where should the reviewer @DANS-KNAW/easy start?

* `ServletEnhancedLogging` is new and used by `DefaultServlet` and via `ServletUtils` by other servlets. It logs the Method, URL, remote address and headers of incoming request
* The rest is only additional unit tests for pruning.

#### How should this be manually tested?

* Examine the output of `StoresServletSpec` after runnig with logging level info at
https://github.com/DANS-KNAW/easy-bag-store/blob/b7530e034dd37e5ddd3c2f2403b3ded5d3feaac9/src/test/resources/logback.xml#L14
  The worst info I see is a header like `Authorization -> Basic Xyz`. I suppose that is configured somewhere on the system so not much of a problem. See also https://github.com/DANS-KNAW/easy-bag-store/pull/65#discussion_r226640657
* Did not yet found the hoops to switch on logging on deasy.

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
