### PR TITLE
EASY-1738 fix easy-bag-store-report.sh

### DIFF
--- a/src/main/assembly/dist/bin/send-bag-store-report.sh
+++ b/src/main/assembly/dist/bin/send-bag-store-report.sh
@@ -43,7 +43,7 @@ exit_if_failed() {
 }
 
 echo -n "Creating list of DOIs in bag-store $BAGSTORE..."
-cat $BAGSTORES_BASEDIR/$BAGSTORE/*/*/*/metadata/dataset.xml | grep 'id-type:DOI' | sed -r 's/^.*>(.*)<.*$/\1/' > $REPORT
+find $BAGSTORES_BASEDIR/$BAGSTORE/ -name 'dataset.xml' | xargs cat | grep 'id-type:DOI' | sed -r 's/^.*>(.*)<.*$/\1/' > $REPORT
 exit_if_failed "DOI list creation failed"
 
 echo -n "Getting total disk usage of bag-store $BAGSTORE..."


### PR DESCRIPTION
Fixes EASY-1738

#### When applied it will...
* allow the `easy-bag-store/src/main/assembly/dist/bin/send-bag-store-report.sh` deal with larger volumes of data

#### Where should the reviewer @DANS-KNAW/easy start?

