### PR TITLE
NO JIRa. Report correct disk usage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.15</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>

--- a/src/main/assembly/dist/bin/send-bag-store-report.sh
+++ b/src/main/assembly/dist/bin/send-bag-store-report.sh
@@ -47,7 +47,7 @@ find $BAGSTORES_BASEDIR/$BAGSTORE/ -name 'dataset.xml' | xargs cat | grep 'id-ty
 exit_if_failed "DOI list creation failed"
 
 echo -n "Getting total disk usage of bag-store $BAGSTORE..."
-DISK_USAGE=$(du -sh $BAGSTORES_BASEDIR/$BAGSTORE)
+DISK_USAGE=$(du -cbsh $BAGSTORES_BASEDIR/$BAGSTORE)
 exit_if_failed "disk space usage report failed"
 
 echo -n "Sending e-mail..."


### PR DESCRIPTION
NO JIRA. Report billable disk usage.

The script send-bag-store-report.sh reported the total disk storage used per
bag-store. This includes the overhead, which is not billable. Added the necessary
command line switches to the du call, with thanks to @Captain-Coder

@DANS-KNAW/easy for review.


