### PR TITLE
EASY-1698: validate UUID length

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -33,8 +33,12 @@ abstract class ItemId(val uuid: UUID) {
 }
 
 object ItemId {
+  // accept both upper and lower case? https://stackoverflow.com/questions/8258480/type-of-character-generated-by-uuid
+  val uuidRegex = "[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}"
+
   def fromString(s: String): Try[ItemId] = Try {
     s.split("/", 2) match {
+      //FIXME is this the best spot to validate uuid?
       case Array(uuidStr) => BagId(UUID.fromString(validateUuid(uuidStr)))
       case Array(uuidStr, path) =>
         FileId(UUID.fromString(validateUuid(uuidStr)), Paths.get(URLDecoder.decode(path, "UTF-8")))
@@ -42,11 +46,10 @@ object ItemId {
   }
 
   def validateUuid(uuidAsString: String): String = {
-    // accept both upper and lower case? https://stackoverflow.com/questions/8258480/type-of-character-generated-by-uuid
-    if (!(uuidAsString.trim.length == 36)) {
+    if (!(uuidAsString.trim.length == 36)) { //FIXME length of 36 is implicitly checked in pattern below
       throw new IllegalArgumentException(s"A UUID should contain 36 characters, this UUID has ${uuidAsString.trim.length}")
     }
-    if (!uuidAsString.matches("[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}")) {
+    if (!uuidAsString.matches(uuidRegex)) { //FIXME need pattern or is length check sufficient?
       throw new IllegalArgumentException(s"The UUID $uuidAsString is not formatted correctly")
     }
     uuidAsString.trim

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -33,15 +33,14 @@ abstract class ItemId(val uuid: UUID) {
 }
 
 object ItemId {
-  // accept both upper and lower case? https://stackoverflow.com/questions/8258480/type-of-character-generated-by-uuid
-  val uuidRegex = "[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}"
+  // FIXME the exact same pattern is also used in dans-bag-lib, share value?
+  val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
 
   def fromString(s: String): Try[ItemId] = Try {
     s.split("/", 2) match {
-      //FIXME is this the best spot to validate uuid?
-      case Array(uuidStr) => BagId(UUID.fromString(validateUuid(uuidStr)))
+      case Array(uuidStr) => BagId(UUID.fromString(validateUuid(uuidStr.toLowerCase)))
       case Array(uuidStr, path) =>
-        FileId(UUID.fromString(validateUuid(uuidStr)), Paths.get(URLDecoder.decode(path, "UTF-8")))
+        FileId(UUID.fromString(validateUuid(uuidStr.toLowerCase())), Paths.get(URLDecoder.decode(path, "UTF-8")))
     }
   }
 
@@ -49,7 +48,8 @@ object ItemId {
     if (!(uuidAsString.trim.length == 36)) { //FIXME length of 36 is implicitly checked in pattern below
       throw new IllegalArgumentException(s"A UUID should contain 36 characters, this UUID has ${uuidAsString.trim.length}")
     }
-    if (!uuidAsString.matches(uuidRegex)) { //FIXME need pattern or is length check sufficient?
+    if (!uuidAsString.trim.matches(uuidRegex)) {
+      println(s"thrown for ${ uuidAsString}")
       throw new IllegalArgumentException(s"The UUID $uuidAsString is not formatted correctly")
     }
     uuidAsString.trim

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -44,7 +44,7 @@ object ItemId {
 
   private def validateUuidLength(uuidAsString: String): String = {
         if (uuidAsString.length > 36) {
-      throw new IllegalArgumentException(s"An UUID should not contain more than 36 characters, this UUID has ${uuidAsString.length}")
+      throw new IllegalArgumentException(s"A UUID should not contain more than 36 characters, this UUID has ${uuidAsString.length}")
     }
     uuidAsString
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -44,15 +44,15 @@ object ItemId {
     }
   }
 
-  def validateUuid(uuidAsString: String): String = {
-    if (!(uuidAsString.trim.length == 36)) { //FIXME length of 36 is implicitly checked in pattern below
-      throw new IllegalArgumentException(s"A UUID should contain 36 characters, this UUID has ${uuidAsString.trim.length}")
+  private def validateUuid(uuidAsString: String): String = {
+    val uuid = uuidAsString.trim.toLowerCase
+    if (uuid.length > 36) { //FIXME length of 36 is implicitly checked in pattern below
+      throw new IllegalArgumentException(s"An UUID should not contain more than 36 characters, this UUID has ${uuid.length}")
     }
-    if (!uuidAsString.trim.matches(uuidRegex)) {
-      println(s"thrown for ${ uuidAsString}")
+    /*if (!uuid.matches(uuidRegex)) {
       throw new IllegalArgumentException(s"The UUID $uuidAsString is not formatted correctly")
-    }
-    uuidAsString.trim
+    }*/
+    uuid
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -43,7 +43,7 @@ object ItemId {
 
   private def validateUuidLength(uuidAsString: String): String = {
     val uuid = uuidAsString.trim
-    if (!(uuid.length == 36)) {
+    if (uuid.length != 36) {
       throw new IllegalArgumentException(s"A UUID should contain exactly 36 characters, this UUID has ${ uuid.length } characters")
     }
     uuid

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -33,26 +33,20 @@ abstract class ItemId(val uuid: UUID) {
 }
 
 object ItemId {
-  // FIXME the exact same pattern is also used in dans-bag-lib, share value?
-  val uuidRegex = "[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}"
 
   def fromString(s: String): Try[ItemId] = Try {
     s.split("/", 2) match {
-      case Array(uuidStr) => BagId(UUID.fromString(validateUuid(uuidStr.toLowerCase)))
+      case Array(uuidStr) => BagId(UUID.fromString(validateUuidLength(uuidStr)))
       case Array(uuidStr, path) =>
-        FileId(UUID.fromString(validateUuid(uuidStr.toLowerCase())), Paths.get(URLDecoder.decode(path, "UTF-8")))
+        FileId(UUID.fromString(validateUuidLength(uuidStr)), Paths.get(URLDecoder.decode(path, "UTF-8")))
     }
   }
 
-  private def validateUuid(uuidAsString: String): String = {
-    val uuid = uuidAsString.trim.toLowerCase
-    if (uuid.length > 36) { //FIXME length of 36 is implicitly checked in pattern below
-      throw new IllegalArgumentException(s"An UUID should not contain more than 36 characters, this UUID has ${uuid.length}")
+  private def validateUuidLength(uuidAsString: String): String = {
+        if (uuidAsString.length > 36) {
+      throw new IllegalArgumentException(s"An UUID should not contain more than 36 characters, this UUID has ${uuidAsString.length}")
     }
-    /*if (!uuid.matches(uuidRegex)) {
-      throw new IllegalArgumentException(s"The UUID $uuidAsString is not formatted correctly")
-    }*/
-    uuid
+    uuidAsString
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -66,7 +66,7 @@ case class FileId(bagId: BagId, path: Path, isDirectory: Boolean = false) extend
   private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
 
   override def toString: String = {
-    s"$bagId/${path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/")}"
+    s"$bagId/${ path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/") }"
   }
 
   override def toBagId: Try[BagId] = Failure(NoBagIdException(this))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -45,7 +45,7 @@ object ItemId {
   private def validateUuidLength(uuidAsString: String): String = {
     val uuid = uuidAsString.trim
     if (!(uuid.length == 36)) {
-      throw new IllegalArgumentException(s"A UUID should contain exactly 36 characters, this UUID has ${uuid.length} characters")
+      throw new IllegalArgumentException(s"A UUID should contain exactly 36 characters, this UUID has ${ uuid.length } characters")
     }
     uuid
   }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -33,7 +33,6 @@ abstract class ItemId(val uuid: UUID) {
 }
 
 object ItemId {
-
   def fromString(s: String): Try[ItemId] = Try {
     s.split("/", 2) match {
       case Array(uuidStr) => BagId(UUID.fromString(validateUuidLength(uuidStr)))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -43,10 +43,11 @@ object ItemId {
   }
 
   private def validateUuidLength(uuidAsString: String): String = {
-        if (uuidAsString.length > 36) {
-      throw new IllegalArgumentException(s"A UUID should not contain more than 36 characters, this UUID has ${uuidAsString.length}")
+    val uuid = uuidAsString.trim
+    if (!(uuid.length == 36)) {
+      throw new IllegalArgumentException(s"A UUID should contain exactly 36 characters, this UUID has ${uuid.length} characters")
     }
-    uuidAsString
+    uuid
   }
 }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -97,7 +97,7 @@ class ItemIdSpec extends TestSupportFixture {
       case Failure(e: NumberFormatException) if e.getMessage.contains(s"For input string: ") =>
     }
     fromString(uuidWithAtSymbol) should matchPattern {
-      case Failure(e: NumberFormatException) if e.getMessage.contains("For input string: ",) =>
+      case Failure(e: NumberFormatException) if e.getMessage.contains("For input string: ") =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -80,8 +80,8 @@ class ItemIdSpec extends TestSupportFixture {
   it should "trigger an IllegalArgumentException when presented a too long UUID should" in {
     val tooLongUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abcdef1278713487134"
     val tooLongUuidAtStart = "12787134871341234abcd-12AB-12ab-12AB-123456abcdef"
-    expectValidationToFail(tooLongUuidAtEnd)
-    expectValidationToFail(tooLongUuidAtStart)
+    expectValidationToFailOnUuidLength(tooLongUuidAtEnd)
+    expectValidationToFailOnUuidLength(tooLongUuidAtStart)
   }
 
   it should "trigger an IllegalArgumentException when presented a nonsense UUID with the right amount of characters" in {
@@ -98,10 +98,10 @@ class ItemIdSpec extends TestSupportFixture {
 
   it should "trigger an IllegalArgumentException when presented a too short UUID" in {
     val tooShortUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abc"
-    expectValidationToFail(tooShortUuidAtEnd)
+    expectValidationToFailOnUuidLength(tooShortUuidAtEnd)
 
     val tooShortUuidAtStart = "bcd-12AB-12ab-12AB-123456abcdef"
-    expectValidationToFail(tooShortUuidAtStart)
+    expectValidationToFailOnUuidLength(tooShortUuidAtStart)
   }
 
   "BagId.toString" should "print UUID" in {
@@ -156,7 +156,7 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  private def expectValidationToFail(nonsenseUuid: String)  = {
+  private def expectValidationToFailOnUuidLength(nonsenseUuid: String)  = {
        fromString(nonsenseUuid)should matchPattern {
           case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -77,10 +77,13 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  it should "trigger an IllegalArgumentException when presented a too long UUID should" in {
+  it should "trigger an IllegalArgumentException when presented a too long UUID at the end should" in {
     val tooLongUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abcdef1278713487134"
-    val tooLongUuidAtStart = "12787134871341234abcd-12AB-12ab-12AB-123456abcdef"
     expectValidationToFailOnUuidLength(tooLongUuidAtEnd)
+  }
+
+  it should "trigger an IllegalArgumentException when presented a too long UUID at the start should" in {
+    val tooLongUuidAtStart = "12787134871341234abcd-12AB-12ab-12AB-123456abcdef"
     expectValidationToFailOnUuidLength(tooLongUuidAtStart)
   }
 
@@ -96,12 +99,14 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  it should "trigger an IllegalArgumentException when presented a too short UUID" in {
-    val tooShortUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abc"
-    expectValidationToFailOnUuidLength(tooShortUuidAtEnd)
-
+  it should "trigger an IllegalArgumentException when presented a too short UUID at start" in {
     val tooShortUuidAtStart = "bcd-12AB-12ab-12AB-123456abcdef"
     expectValidationToFailOnUuidLength(tooShortUuidAtStart)
+  }
+
+  it should "trigger an IllegalArgumentException when presented a too short UUID at the end" in {
+    val tooShortUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abc"
+    expectValidationToFailOnUuidLength(tooShortUuidAtEnd)
   }
 
   "BagId.toString" should "print UUID" in {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -161,9 +161,9 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  private def expectValidationToFailOnUuidLength(nonsenseUuid: String)  = {
-       fromString(nonsenseUuid) should matchPattern {
-          case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
+  private def expectValidationToFailOnUuidLength(nonsenseUuid: String) = {
+    fromString(nonsenseUuid) should matchPattern {
+      case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -21,10 +21,10 @@ import java.util.UUID
 import scala.util.{ Failure, Success }
 
 class ItemIdSpec extends TestSupportFixture {
-  val uuid: UUID = UUID.randomUUID()
-  private val IncorrectLengthMessage = "A UUID should contain 36 characters"
-  private val MixedUuid = "1234abcd-12AB-12ab-12AB-123456abcdef"
-  private val BadFormattedMessage = "is not formatted correctly"
+  private val uuid: UUID = UUID.randomUUID()
+  private val mixedCaseUuid = "1234abcd-12AB-12ab-12AB-123456abcdef"
+  private val incorrectLengthMessage = "A UUID should contain 36 characters"
+  private val badFormattedMessage = "is not formatted correctly"
 
   import ItemId._
 
@@ -75,36 +75,38 @@ class ItemIdSpec extends TestSupportFixture {
 
   it should "not trigger an IllegalArgumentException when presented a valid uuid" in {
     val validUuid = UUID.randomUUID().toString
-    val allUpperUuid = MixedUuid.toUpperCase
-    val allLowerUuid = MixedUuid.toLowerCase
+    val allUpperUuid = mixedCaseUuid.toUpperCase
+    val allLowerUuid = mixedCaseUuid.toLowerCase
     validateUuid(validUuid)
     validateUuid(allLowerUuid)
     validateUuid(allUpperUuid)
-    validateUuid(MixedUuid)
+    validateUuid(mixedCaseUuid)
   }
 
   it should "trigger an IllegalArgumentException when presented a too short UUID should" in {
     val tooShortUuid = UUID.randomUUID().toString.substring(5)
-    expectValidationToFailWithMessage(tooShortUuid, IncorrectLengthMessage)
+    expectValidationToFailWithMessage(tooShortUuid, incorrectLengthMessage)
   }
 
   it should "trigger an IllegalArgumentException when presented a too long UUID should" in {
-    val tooLongUuid = UUID.randomUUID().toString.concat("bunch of characters")
-    expectValidationToFailWithMessage(tooLongUuid, IncorrectLengthMessage)
+    val tooLongUuidAtEnd = uuid.toString.concat("1278713487134")
+    val tooLongUuidAtStart = "1278713487134".concat(uuid.toString)
+    expectValidationToFailWithMessage(tooLongUuidAtEnd, incorrectLengthMessage)
+    expectValidationToFailWithMessage(tooLongUuidAtStart, incorrectLengthMessage)
   }
 
   it should "trigger an IllegalArgumentException when presented a badly formatted UUID should" in {
     val nonsenseUuid = "a badly formatted uuid with 36 chars"
     val uuidWithUnderScore = "____ab12-1234-ascd-1234-123456abcdef"
-    val uuidWithHash = MixedUuid.replaceAll("A", "#")
-    val uuidWithExclamation = MixedUuid.replaceAll("A", "!")
-    val uuidWithWhiteSpace = MixedUuid.replaceAll("2", " ")
+    val uuidWithHash = mixedCaseUuid.replaceAll("A", "#")
+    val uuidWithExclamation = mixedCaseUuid.replaceAll("A", "!")
+    val uuidWithWhiteSpace = mixedCaseUuid.replaceAll("2", " ")
 
-    expectValidationToFailWithMessage(nonsenseUuid, BadFormattedMessage)
-    expectValidationToFailWithMessage(uuidWithUnderScore, BadFormattedMessage)
-    expectValidationToFailWithMessage(uuidWithHash, BadFormattedMessage)
-    expectValidationToFailWithMessage(uuidWithExclamation, BadFormattedMessage)
-    expectValidationToFailWithMessage(uuidWithWhiteSpace, BadFormattedMessage)
+    expectValidationToFailWithMessage(nonsenseUuid, badFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithUnderScore, badFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithHash, badFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithExclamation, badFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithWhiteSpace, badFormattedMessage)
 }
 
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -24,6 +24,7 @@ class ItemIdSpec extends TestSupportFixture {
   val uuid: UUID = UUID.randomUUID()
   private val IncorrectLengthMessage = "A UUID should contain 36 characters"
   private val MixedUuid = "1234abcd-12AB-12ab-12AB-123456abcdef"
+  private val BadFormattedMessage = "is not formatted correctly"
 
   import ItemId._
 
@@ -72,7 +73,7 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  it should "not trigger an illegalArgument exception when presented a valid uuid" in {
+  it should "not trigger an IllegalArgumentException when presented a valid uuid" in {
     val validUuid = UUID.randomUUID().toString
     val allUpperUuid = MixedUuid.toUpperCase
     val allLowerUuid = MixedUuid.toLowerCase
@@ -82,28 +83,30 @@ class ItemIdSpec extends TestSupportFixture {
     validateUuid(MixedUuid)
   }
 
-  it should "trigger an illegalArgument exception when presented a too short UUID should" in {
+  it should "trigger an IllegalArgumentException when presented a too short UUID should" in {
     val tooShortUuid = UUID.randomUUID().toString.substring(5)
-    doTestValidateUuid(tooShortUuid, IncorrectLengthMessage)
+    expectValidationToFailWithMessage(tooShortUuid, IncorrectLengthMessage)
   }
 
-  it should "trigger an illegalArgument exception when presented a too long UUID should" in {
+  it should "trigger an IllegalArgumentException when presented a too long UUID should" in {
     val tooLongUuid = UUID.randomUUID().toString.concat("bunch of characters")
-    doTestValidateUuid(tooLongUuid, IncorrectLengthMessage)
+    expectValidationToFailWithMessage(tooLongUuid, IncorrectLengthMessage)
   }
 
-  it should "trigger an illegalArgument exception when presented a badly formatted UUID should" in {
+  it should "trigger an IllegalArgumentException when presented a badly formatted UUID should" in {
     val nonsenseUuid = "a badly formatted uuid with 36 chars"
     val uuidWithUnderScore = "____ab12-1234-ascd-1234-123456abcdef"
     val uuidWithHash = MixedUuid.replaceAll("A", "#")
     val uuidWithExclamation = MixedUuid.replaceAll("A", "!")
     val uuidWithWhiteSpace = MixedUuid.replaceAll("2", " ")
-    doTestValidateUuid(nonsenseUuid, "is not formatted correctly")
-    doTestValidateUuid(uuidWithUnderScore, "is not formatted correctly")
-    doTestValidateUuid(uuidWithHash, "is not formatted correctly")
-    doTestValidateUuid(uuidWithExclamation, "is not formatted correctly")
-    doTestValidateUuid(uuidWithWhiteSpace, "is not formatted correctly")
-  }
+
+    expectValidationToFailWithMessage(nonsenseUuid, BadFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithUnderScore, BadFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithHash, BadFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithExclamation, BadFormattedMessage)
+    expectValidationToFailWithMessage(uuidWithWhiteSpace, BadFormattedMessage)
+}
+
 
   "BagId.toString" should "print UUID" in {
     BagId(uuid).toString shouldBe uuid.toString
@@ -157,7 +160,7 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  private def doTestValidateUuid(nonsenseUuid: String, expectedMessage: String) = {
+  private def expectValidationToFailWithMessage(nonsenseUuid: String, expectedMessage: String) = {
     try {
       validateUuid(nonsenseUuid)
       fail("too short uuid should throw an illegal argument exception")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -73,7 +73,7 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  it should "not trigger an IllegalArgumentException when presented a valid uuid" in {
+  "validateUuid" should "not trigger an IllegalArgumentException when presented a valid uuid" in {
     val validUuid = UUID.randomUUID().toString
     val allUpperUuid = mixedCaseUuid.toUpperCase
     val allLowerUuid = mixedCaseUuid.toLowerCase

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -155,7 +155,7 @@ class ItemIdSpec extends TestSupportFixture {
 
   private def expectValidationToFail(nonsenseUuid: String)  = {
        fromString(nonsenseUuid)should matchPattern {
-          case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"An UUID should not contain more than 36 characters, this UUID has ${ nonsenseUuid.length }") =>
+          case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should not contain more than 36 characters, this UUID has ${ nonsenseUuid.length }") =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 import java.util.UUID
 
 
-import scala.util.{Failure, Success}
+import scala.util.{ Failure, Success }
 
 class ItemIdSpec extends TestSupportFixture {
   private val uuid: UUID = UUID.randomUUID()
@@ -161,9 +161,9 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  private def expectValidationToFailOnUuidLength(nonsenseUuid: String)  = {
-       fromString(nonsenseUuid)should matchPattern {
-          case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
+  private def expectValidationToFailOnUuidLength(nonsenseUuid: String) = {
+    fromString(nonsenseUuid) should matchPattern {
+      case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -73,7 +73,7 @@ class ItemIdSpec extends TestSupportFixture {
 
   "fromString" should "not trigger an IllegalArgumentException when presented a valid uuid" in {
     fromString(uuid.toString) should matchPattern {
-      case Success(id: BagId) if id.uuid.equals(uuid) =>
+      case Success(BagId(`uuid`)) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -162,7 +162,7 @@ class ItemIdSpec extends TestSupportFixture {
   }
 
   private def expectValidationToFailOnUuidLength(nonsenseUuid: String)  = {
-       fromString(nonsenseUuid)should matchPattern {
+       fromString(nonsenseUuid) should matchPattern {
           case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -184,14 +184,6 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
-  it should "fail when the given uuid is too short" in {
-    val tooShortUuid = "0000-0000-0000-0000-000000000001"
-    get(s"/${ tooShortUuid }") {
-      status shouldBe 400
-      body shouldBe s"invalid UUID string: $tooShortUuid"
-    }
-  }
-
   it should "fail when the bag is not found" in {
     get(s"/${ UUID.randomUUID() }") {
       status shouldBe 404

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -176,6 +176,22 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
+  it should "fail when the given uuid is too long" in {
+    val tooLongUuid = "01000000-0000-0000-0000-0000000000011234465565"
+    get(s"/${ tooLongUuid }") {
+      status shouldBe 400
+      body shouldBe s"invalid UUID string: $tooLongUuid"
+    }
+  }
+
+  it should "fail when the given uuid is too short" in {
+    val tooShortUuid = "0000-0000-0000-0000-000000000001"
+    get(s"/${ tooShortUuid }") {
+      status shouldBe 400
+      body shouldBe s"invalid UUID string: $tooShortUuid"
+    }
+  }
+
   it should "fail when the bag is not found" in {
     get(s"/${ UUID.randomUUID() }") {
       status shouldBe 404

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -184,6 +184,14 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
+  it should "fail when the given uuid is too short" in {
+    val tooShortUuid = "01000000-0000-0000-0000-0000"
+    get(s"/${ tooShortUuid }") {
+      status shouldBe 400
+      body shouldBe s"invalid UUID string: $tooShortUuid"
+    }
+  }
+
   it should "fail when the bag is not found" in {
     get(s"/${ UUID.randomUUID() }") {
       status shouldBe 404

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -421,7 +421,7 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "fail when another type of credentials is provided" in  {
+  it should "fail when another type of credentials is provided" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), authenticationHeader("foo", "bar", "Bearer")) {
       status shouldBe 400
@@ -429,7 +429,7 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "fail when invalid BasicAuth credentials are provided" in  {
+  it should "fail when invalid BasicAuth credentials are provided" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), authenticationHeader("wrong-username", "wrong-password")) {
       status shouldBe 401
@@ -438,7 +438,7 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "fail when a second call does not provide credentials" in  {
+  it should "fail when a second call does not provide credentials" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
     putBag(uuid, testBagUnprunedA)
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA)) {


### PR DESCRIPTION
Fixes EASY-1698 

#### When applied it will...
* validate if an uuid contains exactly 36 characters
* validate if an uuid is properly formatted

#### Where should the reviewer @DANS-KNAW/easy start?

nl.knaw.dans.easy.bagstore.itemIdSpec#validateUuid(uuidAsString: String)


### How should this be manually tested?
curl to the api {server_address/:uuid}  - {server_address/:uuid/*} with:
* a few valid uuid's => 200'ish  
* a few invalid uuid's => 400

valid format: https://en.wikipedia.org/wiki/Universally_unique_identifier#Format