### PR TITLE
EASY-1640 command line incorrect fetch.txt file results in unclear error messaging

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -125,7 +125,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
           if (itemIdPath.getNameCount > 1)
             Try(FileId(bagId, itemIdPath.subpath(1, itemIdPath.getNameCount)))
           else if (uri.toString.endsWith("/"))
-            Try(FileId(bagId, Paths.get("")))
+                 Try(FileId(bagId, Paths.get("")))
           else
             Try(bagId)
         }
@@ -224,6 +224,8 @@ trait FileSystemComponent extends DebugEnhancedLogging {
             fileId <- id.toFileId
             location <- toRealLocation(fileId)
           } yield (bagDir.toAbsolutePath.resolve(item.path), location)
+        } recoverWith {
+          case e: Exception => Failure(new IllegalArgumentException(s"Bag-id found in fetch.txt can not be found in the bag-store: ${ e.getMessage }"))
         }).collectResults
       } yield mapping
     }
@@ -264,7 +266,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
     /**
      * Creates a copy of a directory tree, in which every 'regular' file is a symlink back to the source tree.
      *
-     * @param src the root of the tree to copy
+     * @param src    the root of the tree to copy
      * @param target the root of the copy
      * @return
      */

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -225,7 +225,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
             location <- toRealLocation(fileId)
           } yield (bagDir.toAbsolutePath.resolve(item.path), location)
         } recoverWith {
-          case nsfe: NoSuchFileException => Failure(new IllegalArgumentException(s"Bag-id found in fetch.txt can not be found in the bag-store: ${ nsfe.getMessage }"))
+          case nsfe: NoSuchFileException => Failure(new IllegalArgumentException(s"Local-file-uri found in fetch.txt can not be found in the bag-store: ${ nsfe.getMessage }"))
         }).collectResults
       } yield mapping
     }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -125,7 +125,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
           if (itemIdPath.getNameCount > 1)
             Try(FileId(bagId, itemIdPath.subpath(1, itemIdPath.getNameCount)))
           else if (uri.toString.endsWith("/"))
-                 Try(FileId(bagId, Paths.get("")))
+            Try(FileId(bagId, Paths.get("")))
           else
             Try(bagId)
         }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -225,7 +225,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
             location <- toRealLocation(fileId)
           } yield (bagDir.toAbsolutePath.resolve(item.path), location)
         } recoverWith {
-          case e: Exception => Failure(new IllegalArgumentException(s"Bag-id found in fetch.txt can not be found in the bag-store: ${ e.getMessage }"))
+          case nsfe: NoSuchFileException => Failure(new IllegalArgumentException(s"Bag-id found in fetch.txt can not be found in the bag-store: ${ nsfe.getMessage }"))
         }).collectResults
       } yield mapping
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.bagstore.component
 
 import java.net.URI
 import java.nio.file.attribute.{ PosixFilePermission, PosixFilePermissions }
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
 import java.util.UUID
 
 import better.files.File
@@ -173,16 +173,11 @@ class BagStoreSpec extends TestSupportFixture
   it should "result in a failure when the fetch.txt is invalid" in {
     val uuid1 = UUID.fromString("00000000-0000-0000-0000-000000000001")
     val fetchFile = File(testBagPrunedB.resolve("fetch.txt"))
-    val exceptionMessageSuffix = "Bag-id found in fetch.txt can not be found in the bag-store:"
 
     Files.write(fetchFile.path, fetchFile.contentAsString.replaceAll("01", "10").getBytes())
 
     bagStore.add(testBagPrunedB, Some(uuid1)) should matchPattern {
-       case Failure(CompositeException(errors)) if oneOfTheErrorsContainsMessage(exceptionMessageSuffix, errors) =>
+       case Failure(CompositeException(errors)) if errors.exists(_.isInstanceOf[IllegalArgumentException]) =>
     }
-  }
-
-  private def oneOfTheErrorsContainsMessage(exceptionMessageSuffix: String, errors: List[Throwable]) = {
-    errors.headOption.getOrElse(new Exception()).getMessage contains exceptionMessageSuffix
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -178,7 +178,7 @@ class BagStoreSpec extends TestSupportFixture
     Files.write(fetchFile.path, fetchFile.contentAsString.replaceAll("01", "10").getBytes())
 
     bagStore.add(testBagPrunedB, Some(uuid1)) should matchPattern {
-      case Failure(CompositeException(errors)) if errors.head.getMessage contains exceptionMessageSuffix =>
+       case Failure(CompositeException(errors)) if errors.headOption.getOrElse(new Exception()).getMessage contains exceptionMessageSuffix =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -15,18 +15,17 @@
  */
 package nl.knaw.dans.easy.bagstore.component
 
-import java.io.PrintWriter
 import java.net.URI
 import java.nio.file.attribute.{ PosixFilePermission, PosixFilePermissions }
 import java.nio.file.{ Files, Path, Paths }
 import java.util.UUID
 
+import better.files.File
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error.CompositeException
 import org.apache.commons.io.FileUtils
 import org.scalatest.OneInstancePerTest
 
-import scala.io.Source
 import scala.util.{ Failure, Success }
 
 class BagStoreSpec extends TestSupportFixture
@@ -173,22 +172,13 @@ class BagStoreSpec extends TestSupportFixture
 
   it should "result in a failure when the fetch.txt is invalid" in {
     val uuid1 = UUID.fromString("00000000-0000-0000-0000-000000000001")
-    val tmpFile = testBagPrunedB.resolve("fetch2.txt").toFile
-    val fetchFilePath = testBagPrunedB.resolve("fetch.txt")
-    val exceptionSuffixMessage = "Bag-id found in fetch.txt can not be found in the bag-store:"
-    val printWriter = new PrintWriter(tmpFile)
+    val fetchFile = File(testBagPrunedB.resolve("fetch.txt"))
+    val exceptionMessageSuffix = "Bag-id found in fetch.txt can not be found in the bag-store:"
 
-    Source
-      .fromFile(fetchFilePath.toFile)
-      .getLines()
-      .map(line => line.replaceAll("01", "10"))
-      .foreach(printWriter.println)
-
-    printWriter.close()
-    tmpFile.renameTo(fetchFilePath.toFile)
+    Files.write(fetchFile.path,  fetchFile.contentAsString.replaceAll("01", "10").getBytes())
 
     bagStore.add(testBagPrunedB, Some(uuid1)) should matchPattern {
-      case Failure(ce: CompositeException) if ce.throwables.head.getMessage contains exceptionSuffixMessage =>
+      case Failure(CompositeException(errors)) if errors.head.getMessage contains exceptionMessageSuffix =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -178,7 +178,11 @@ class BagStoreSpec extends TestSupportFixture
     Files.write(fetchFile.path, fetchFile.contentAsString.replaceAll("01", "10").getBytes())
 
     bagStore.add(testBagPrunedB, Some(uuid1)) should matchPattern {
-       case Failure(CompositeException(errors)) if errors.headOption.getOrElse(new Exception()).getMessage contains exceptionMessageSuffix =>
+       case Failure(CompositeException(errors)) if oneOfTheErrorsContainsMessage(exceptionMessageSuffix, errors) =>
     }
+  }
+
+  private def oneOfTheErrorsContainsMessage(exceptionMessageSuffix: String, errors: List[Throwable]) = {
+    errors.headOption.getOrElse(new Exception()).getMessage contains exceptionMessageSuffix
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -175,11 +175,10 @@ class BagStoreSpec extends TestSupportFixture
     val fetchFile = File(testBagPrunedB.resolve("fetch.txt"))
     val exceptionMessageSuffix = "Bag-id found in fetch.txt can not be found in the bag-store:"
 
-    Files.write(fetchFile.path,  fetchFile.contentAsString.replaceAll("01", "10").getBytes())
+    Files.write(fetchFile.path, fetchFile.contentAsString.replaceAll("01", "10").getBytes())
 
     bagStore.add(testBagPrunedB, Some(uuid1)) should matchPattern {
       case Failure(CompositeException(errors)) if errors.head.getMessage contains exceptionMessageSuffix =>
     }
   }
-
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -178,6 +178,7 @@ class BagStoreSpec extends TestSupportFixture
 
     inside(bagStore.add(testBagPrunedB, Some(uuid1))) {
       case Failure(CompositeException(errors)) =>
+        errors should have size 4
         forEvery(errors)(e => {
           e shouldBe an[IllegalArgumentException]
           e.getMessage should include("Local-file-uri found in fetch.txt can not be found in the bag-store: ")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -180,7 +180,7 @@ class BagStoreSpec extends TestSupportFixture
       case Failure(CompositeException(errors)) if errors
         .find(_.isInstanceOf[IllegalArgumentException])
         .getOrElse(new TestFailedException(1)) // if no IllegalStateException is present the test has failed
-        .getMessage.contains("Local-file-uri found in fetch.txt can not be found in the bag-store: 123") =>
+        .getMessage.contains("Local-file-uri found in fetch.txt can not be found in the bag-store: ") =>
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-1640

#### When applied it will...
* log a more user friendly error

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
