### PR TITLE
EASY-1633 check if file is hidden when returning bag

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -49,7 +49,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
     case Some(cmd @ commandLine.get) =>
       for {
         itemId <- ItemId.fromString(cmd.itemId())
-        (path, store) <- bagStores.copyToDirectory(itemId, cmd.outputDir(), cmd.skipCompletion(), bagStoreBaseDir)
+        (path, store) <- bagStores.copyToDirectory(itemId, cmd.outputDir(), cmd.skipCompletion(), bagStoreBaseDir, cmd.forceInactive())
         storeName = getStoreName(store)
       } yield s"Retrieved item with item-id: $itemId to ${ path } from bag store: $storeName"
     case Some(cmd @ commandLine.stream) =>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -62,7 +62,6 @@ trait CommandLineOptionsComponent {
          |Options:
          |""".stripMargin)
 
-
     private implicit val fileConverter: ValueConverter[Path] = singleArgConverter[Path](s => Paths.get(resolveTildeToHomeDir(s)))
     private implicit val uuidParser: ValueConverter[UUID] = singleArgConverter(UUID.fromString)
     private implicit val archiveStreamTypeParser: ValueConverter[ArchiveStreamType.Value] = singleArgConverter {
@@ -175,9 +174,10 @@ trait CommandLineOptionsComponent {
     addSubcommand(reactivate)
 
     val prune = new Subcommand("prune") {
-      descr("""Removes Files from bag, that are already found in reference bags, replacing them with
-              |fetch.txt references.
-              |""".stripMargin)
+      descr(
+        """Removes Files from bag, that are already found in reference bags, replacing them with
+          |fetch.txt references.
+          |""".stripMargin)
       val bagDir: ScallopOption[Path] = trailArg[Path](name = "<bag-dir>",
         descr = "bag directory to prune",
         required = true)
@@ -198,7 +198,6 @@ trait CommandLineOptionsComponent {
       footer(SUBCOMMAND_SEPARATOR)
     }
     addSubcommand(complete)
-
 
     val validate = new Subcommand("validate") {
       descr("Checks that <bag-dir> is a virtually-valid bag")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -28,7 +28,6 @@ import resource._
 import scala.collection.JavaConverters._
 import scala.language.postfixOps
 import scala.util.control.NonFatal
-import scala.util.parsing.combinator.Parsers
 import scala.util.{ Failure, Success, Try }
 
 trait BagStoreComponent {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -99,8 +99,8 @@ trait BagStoreComponent {
      * The file and directory permissions on the result are changed recursively to the values configured in
      * `cli.output.bag-file-permissions` and `cli.output.bag-dir-permissions`.
      *
-     * @param itemId the item to copy
-     * @param output the directory to copy it to
+     * @param itemId         the item to copy
+     * @param output         the directory to copy it to
      * @param skipCompletion if `true` no files will be fetched from other locations
      * @return
      */
@@ -184,7 +184,7 @@ trait BagStoreComponent {
                   Files.copy(path, outputStream)
                 })
             }
-            else if(allEntries.isEmpty) Failure(NoSuchItemException(itemId))
+            else if (allEntries.isEmpty) Failure(NoSuchItemException(itemId))
             else Failure(NoRegularFileException(itemId))
           }
         } yield ()
@@ -192,8 +192,8 @@ trait BagStoreComponent {
     }
 
     private def validateThatFileIsActive(path: Path, itemId: ItemId): Try[Unit] = {
-        if (Files.isHidden(path)) Failure(InactiveException(itemId, forceInactive = false))
-        else Success(())
+      if (Files.isHidden(path)) Failure(InactiveException(itemId, forceInactive = false))
+      else Success(())
     }
 
     private def createEntrySpec(source: Option[Path], bagDir: Path, itemPath: Path, fileId: FileId): EntrySpec = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -162,7 +162,7 @@ trait BagStoreComponent {
         for {
           bagDir <- fileSystem.toLocation(bagId)
           itemPath <- itemId.toFileId.map(f => bagDir.resolve(f.path)).orElse(Success(bagDir))
-          _ <- activeStatusMatchesRequestParams(itemPath, itemId)
+          _ <- validateThatFileIsActive(itemPath, itemId)
           fileIds <- enumFiles(itemId)
           fileSpecs <- fileIds.filter(!_.isDirectory).map {
             fileId =>
@@ -194,7 +194,7 @@ trait BagStoreComponent {
       }
     }
 
-    private def activeStatusMatchesRequestParams(path: Path, itemId: ItemId): Try[Unit] = {
+    private def validateThatFileIsActive(path: Path, itemId: ItemId): Try[Unit] = {
         if (Files.isHidden(path)) Failure(InactiveException(itemId, forceInactive = false))
         else Success(())
     }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -154,7 +154,7 @@ trait BagStoreComponent {
      * @param outputStream      the output stream to write to
      * @return whether the call was successful
      */
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, forceInactive: Boolean = false): Try[Unit] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream): Try[Unit] = {
       trace(itemId)
       val bagId = BagId(itemId.uuid)
 
@@ -162,7 +162,7 @@ trait BagStoreComponent {
         for {
           bagDir <- fileSystem.toLocation(bagId)
           itemPath <- itemId.toFileId.map(f => bagDir.resolve(f.path)).orElse(Success(bagDir))
-          _ <- activeStatusMatchesRequestParams(itemPath, forceInactive, itemId)
+          _ <- activeStatusMatchesRequestParams(itemPath, itemId)
           fileIds <- enumFiles(itemId)
           fileSpecs <- fileIds.filter(!_.isDirectory).map {
             fileId =>
@@ -194,8 +194,8 @@ trait BagStoreComponent {
       }
     }
 
-    private def activeStatusMatchesRequestParams(path: Path, forceInactive: Boolean, itemId: ItemId): Try[Unit] = {
-        if (Files.isHidden(path) && !forceInactive) Failure(InactiveException(itemId, forceInactive))
+    private def activeStatusMatchesRequestParams(path: Path, itemId: ItemId): Try[Unit] = {
+        if (Files.isHidden(path)) Failure(InactiveException(itemId, forceInactive = false))
         else Success(())
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -114,9 +114,7 @@ trait BagStoreComponent {
             case bagId: BagId =>
               fileSystem.toLocation(bagId)
                 .map(path => {
-                  if (Files.isHidden(path) && !forceInactive) throw InactiveException(itemId, forceInactive)
-                  val resultDir = output.resolve(path.getFileName).toAbsolutePath
-                  if (Files.exists(resultDir)) throw OutputAlreadyExists(resultDir)
+                  val resultDir: BaseDir = validatePathAndResolveResultDirectory(itemId, output, forceInactive, path)
                   debug(s"Copying bag from $path to $output")
                   FileUtils.copyDirectory(path.toFile, resultDir.toFile)
                   if (!skipCompletion) bagProcessing.complete(resultDir)
@@ -284,6 +282,12 @@ trait BagStoreComponent {
     }
   }
 
+  private def validatePathAndResolveResultDirectory(itemId: ItemId, output: BaseDir, forceInactive: Boolean, path: BaseDir) = {
+    if (Files.isHidden(path) && !forceInactive) throw InactiveException(itemId, forceInactive)
+    val resultDir = output.resolve(path.getFileName).toAbsolutePath
+    if (Files.exists(resultDir)) throw OutputAlreadyExists(resultDir)
+    resultDir
+  }
   object BagStore {
     def apply(dir: BaseDir): BagStore = new BagStore {
       implicit val baseDir: BaseDir = dir

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -37,12 +37,12 @@ trait BagStoresComponent {
     def storeShortnames: Map[String, BaseDir]
     def getBaseDirByShortname(name: String): Option[BaseDir] = storeShortnames.get(name)
 
-    def copyToDirectory(itemId: ItemId, output: Path, skipCompletion: Boolean = false, fromStore: Option[BaseDir] = None): Try[(Path, BaseDir)] = {
+    def copyToDirectory(itemId: ItemId, output: Path, skipCompletion: Boolean = false, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[(Path, BaseDir)] = {
       fromStore
-        .map(BagStore(_).copyToDirectory(itemId, output, skipCompletion))
+        .map(BagStore(_).copyToDirectory(itemId, output, skipCompletion, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).copyToDirectory(itemId, output, skipCompletion))
+            .map(BagStore(_).copyToDirectory(itemId, output, skipCompletion, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -51,12 +51,12 @@ trait BagStoresComponent {
         }
     }
 
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None): Try[Unit] = {
       fromStore
-        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
+        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
+            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -51,12 +51,12 @@ trait BagStoresComponent {
         }
     }
 
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None): Try[Unit] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
       fromStore
-        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
+        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
+            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -35,6 +35,7 @@ trait BagStoresComponent {
 
   trait BagStores {
     def storeShortnames: Map[String, BaseDir]
+
     def getBaseDirByShortname(name: String): Option[BaseDir] = storeShortnames.get(name)
 
     def copyToDirectory(itemId: ItemId, output: Path, skipCompletion: Boolean = false, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[(Path, BaseDir)] = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -45,6 +45,7 @@ package object bagstore {
   case class NoFileIdException(itemId: ItemId) extends Exception(s"item-id $itemId is not a file-id")
   case class CorruptBagStoreException(reason: String) extends Exception(s"BagStore seems to be corrupt: $reason")
   case class OutputAlreadyExists(path: Path) extends Exception(s"Output path already exists; not overwriting $path")
+  case class InactiveException(itemId: ItemId, forceInactive: Boolean) extends Exception(s"Tried to retrieve an inactive bag: ${ itemId.uuid } with toggle forceInactive = $forceInactive")
   case class OutputNotADirectoryException(path: Path) extends Exception(s"Output path must be a directory; $path exists, but is not a directory.")
   case class NoBagException(cause: Throwable) extends Exception("The provided input did not contain a bag", cause)
   case class InvalidBagException(bagId: BagId, msg: String) extends Exception(s"Bag $bagId is not a valid bag: $msg")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreServerComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreServerComponent.scala
@@ -16,7 +16,6 @@
 package nl.knaw.dans.easy.bagstore.server
 
 import javax.servlet.ServletContext
-
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.scalatra.LifeCycle

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -23,7 +23,6 @@ import nl.knaw.dans.easy.bagstore.component.{ BagStoresComponent, FileSystemComp
 import nl.knaw.dans.easy.bagstore.server.ServletEnhancedLogging._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import org.apache.commons.lang3.BooleanUtils
 import org.joda.time.DateTime
 import org.scalatra._
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -97,7 +97,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
           })
           .getOrRecover {
             case e: NoBagIdException => InternalServerError(e.getMessage)
-            case e : InactiveException => Conflict(e.getMessage)
+            case e: InactiveException => Conflict(e.getMessage)
             case e: IllegalArgumentException => BadRequest(e.getMessage)
             case e: NoRegularFileException => BadRequest(e.getMessage)
             case e: NoSuchItemException => NotFound(e.getMessage)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -81,7 +81,6 @@ trait StoresServletComponent extends DebugEnhancedLogging {
       val bagstore = params("bagstore")
       val uuidStr = params("uuid")
       val accept = request.getHeader("Accept")
-      val forceInactive = BooleanUtils.toBoolean(params.getOrElse("forceInactive", "false"))
       bagStores.getBaseDirByShortname(bagstore)
         .map(baseDir => ItemId.fromString(uuidStr)
           .recoverWith {
@@ -94,7 +93,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
               .enumFiles(bagId, includeDirectories = false, Some(baseDir))
               .map(files => Ok(files.toList.mkString("\n")))
             else bagStores
-              .copyToStream(bagId, accept, response.outputStream, Some(baseDir), forceInactive)
+              .copyToStream(bagId, accept, response.outputStream, Some(baseDir))
               .map(_ => Ok())
           })
           .getOrRecover {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -99,7 +99,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
           })
           .getOrRecover {
             case e: NoBagIdException => InternalServerError(e.getMessage)
-            case e : InactiveException => BadRequest(e.getMessage)
+            case e : InactiveException => Conflict(e.getMessage)
             case e: IllegalArgumentException => BadRequest(e.getMessage)
             case e: NoRegularFileException => BadRequest(e.getMessage)
             case e: NoSuchItemException => NotFound(e.getMessage)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoreSpec.scala
@@ -152,7 +152,6 @@ class BagStoreSpec extends TestSupportFixture
     fileSystem.bagDirPermissions.clear()
     fileSystem.bagDirPermissions.addAll(dirPermissions)
 
-
     val uuid1 = UUID.fromString("11111111-1111-1111-1111-111111111111")
     testSuccessfulAdd(testValidBag, uuid1)
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -106,21 +106,13 @@ class BagStoresSpec extends TestSupportFixture
       case Failure(_: InactiveException) =>
     }
     // with force option results bagId a success
-    bagStore1.copyToDirectory(bagId, output.resolve("a1"), false, true) should matchPattern {
-      case Success(_) =>
-    }
+    bagStore1.copyToDirectory(bagId, output.resolve("a1"), false, true) shouldBe a[Success[_]]
     // make deposit active again
-    bagStore1.reactivate(bagId) should matchPattern {
-      case Success(_) =>
-    }
+    bagStore1.reactivate(bagId) shouldBe a[Success[_]]
     // now it works again without the force option
-    bagStore1.copyToDirectory(bagId, output.resolve("a2"), false, false) should matchPattern {
-      case Success(_) =>
-    }
+    bagStore1.copyToDirectory(bagId, output.resolve("a2"), false, false) shouldBe a[Success[_]]
     // it also works  with the force option
-    bagStore1.copyToDirectory(bagId, output.resolve("a3"), false, false) should matchPattern {
-      case Success(_) =>
-    }
+    bagStore1.copyToDirectory(bagId, output.resolve("a3"), false, false) shouldBe a[Success[_]]
   }
 
   // TODO: add tests for failures

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -100,17 +100,19 @@ class BagStoresSpec extends TestSupportFixture
   }
 
   it should "result in a failure when a get is done on a hidden file with forceInactive=false" in {
-    val output = testDir.resolve("pruned-output")
+    val output = testDir.resolve("pruned-output/hidden/test")
     inside(bagStore1.add(testBagPrunedA)) { case Success(result) =>
       bagStores.copyToDirectory(result, output, skipCompletion = true) shouldBe a[Success[_]]
       pathsEqual(testBagPrunedA, output.resolve("a")) shouldBe true
+
+      // deactivate deposit
       inside(bagStore1.deactivate(result)) { case Success(()) =>
         // without force option results in failure
         inside(bagStore1.copyToDirectory(result, output.resolve("a1"), false, false)) {
            case Failure(e: InactiveException) => Success(())
         }
         // with force option results in a success
-        inside(bagStore1.copyToDirectory(result, output.resolve("a2"), false, true)) {
+        inside(bagStore1.copyToDirectory(result, output.resolve("a1"), false, true)) {
           case Success(_) =>
         }
         // make deposit active again
@@ -118,17 +120,16 @@ class BagStoresSpec extends TestSupportFixture
           case Success(_) =>
         }
         // now it works again without the force option
-        inside(bagStore1.copyToDirectory(result, output.resolve("a3"), false, false)) {
+        inside(bagStore1.copyToDirectory(result, output.resolve("a2"), false, false)) {
           case Success(_) =>
         }
         // it also works  with the force option
-        inside(bagStore1.copyToDirectory(result, output.resolve("a4"), false, false)) {
+        inside(bagStore1.copyToDirectory(result, output.resolve("a3"), false, false)) {
           case Success(_) =>
         }
       }
     }
   }
-
 
   // TODO: add tests for failures
   // TODO: add tests for file permissions

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -112,7 +112,7 @@ class BagStoresSpec extends TestSupportFixture
            case Failure(e: InactiveException) => Success(())
         }
         // with force option results in a success
-        inside(bagStore1.copyToDirectory(result, output.resolve("a1"), false, true)) {
+         bagStore1.copyToDirectory(result, output.resolve("a1"), false, true) shouldBe a[Success[_]]
           case Success(_) =>
         }
         // make deposit active again

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -340,7 +340,7 @@ class StoresServletSpec extends TestSupportFixture
     }
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 400
-      body shouldBe InactiveException(bagId, false).getMessage
+      body shouldBe InactiveException(bagId, forceInactive = false).getMessage
     }
   }
 
@@ -349,7 +349,7 @@ class StoresServletSpec extends TestSupportFixture
     inside(bagStore1.deactivate(bagId)) {
       case Success(_) =>
     }
-    get(s"/store1/bags/${ bagId }?forceInactive=true", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
+    get(s"/store1/bags/$bagId", params = Map("forceInactive" -> "true"), headers = Map("Accept" -> "application/zip")) {
       status shouldBe 200
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -339,7 +339,7 @@ class StoresServletSpec extends TestSupportFixture
       case Success(_) =>
     }
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
-      status shouldBe 400
+      status shouldBe 409
       body shouldBe InactiveException(bagId, forceInactive = false).getMessage
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -333,6 +333,27 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
+  it should "fail when an inactive bag is requested with the wrong queryParams" in {
+    val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
+    inside(bagStore1.deactivate(bagId)) {
+      case Success(_) =>
+    }
+    get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
+      status shouldBe 400
+      body shouldBe InactiveException(bagId, false).getMessage
+    }
+  }
+
+  it should "succeed when an inactive bag is requested  and the querParams forceInactive=true are supplied" in {
+    val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
+    inside(bagStore1.deactivate(bagId)) {
+      case Success(_) =>
+    }
+    get(s"/store1/bags/${ bagId }?forceInactive=true", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
+      status shouldBe 200
+    }
+  }
+
   def authenticationHeader(username: String, password: String, authType: String = "Basic"): List[(String, String)] = {
     val encoded = Base64.getEncoder.encodeToString(s"$username:$password")
     List("Authorization" -> s"$authType $encoded")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -335,10 +335,7 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "fail when an inactive bag is requested with the wrong queryParams" in {
     val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
-    inside(bagStore1.deactivate(bagId)) {
-      case Success(_) =>
-      case _ => fail
-    }
+    bagStore1.deactivate(bagId) shouldBe a[Success[_]]
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 409
       body shouldBe InactiveException(bagId, forceInactive = false).getMessage

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -337,6 +337,7 @@ class StoresServletSpec extends TestSupportFixture
     val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
     inside(bagStore1.deactivate(bagId)) {
       case Success(_) =>
+      case _ => fail
     }
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 409

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -344,16 +344,6 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "succeed when an inactive bag is requested  and the querParams forceInactive=true are supplied" in {
-    val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
-    inside(bagStore1.deactivate(bagId)) {
-      case Success(_) =>
-    }
-    get(s"/store1/bags/$bagId", params = Map("forceInactive" -> "true"), headers = Map("Accept" -> "application/zip")) {
-      status shouldBe 200
-    }
-  }
-
   def authenticationHeader(username: String, password: String, authType: String = "Basic"): List[(String, String)] = {
     val encoded = Base64.getEncoder.encodeToString(s"$username:$password")
     List("Authorization" -> s"$authType $encoded")


### PR DESCRIPTION
- [x] command line tool
- [x]  HTTP

Fixes EASY-1633

#### When applied it will...
* check if a file is hidden (active) before returning bag
* return a conflict if an inactive bag is request through http


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 