### PR TITLE
EASY-1632 easy-bag-store should return 404 instead of 500 when an item is not found

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.bagstore.server
 
 import nl.knaw.dans.easy.bagstore.component.BagStoresComponent
 import nl.knaw.dans.easy.bagstore.server.ServletEnhancedLogging._
-import nl.knaw.dans.easy.bagstore.{ ItemId, NoRegularFileException, NoSuchBagException, NoSuchFileItemException }
+import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.joda.time.DateTime
@@ -88,6 +88,7 @@ trait BagsServletComponent extends DebugEnhancedLogging {
               case e: NoRegularFileException => BadRequest(e.getMessage)
               case e: NoSuchBagException => NotFound(e.getMessage)
               case e: NoSuchFileItemException => NotFound(e.getMessage)
+              case e: NoSuchItemException => NotFound(e.getMessage)
               case NonFatal(e) =>
                 logger.error("Error retrieving bag", e)
                 InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -19,7 +19,7 @@ import java.nio.file.{ Files, Paths }
 import java.util.UUID
 
 import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
-import nl.knaw.dans.easy.bagstore.{ BagStoresFixture, BagitFixture, ServletFixture, TestSupportFixture }
+import nl.knaw.dans.easy.bagstore._
 import org.apache.commons.io.FileUtils
 import org.scalatra.test.scalatest.ScalatraSuite
 
@@ -195,6 +195,14 @@ class BagsServletSpec extends TestSupportFixture
   it should "fail when the bag is not found" in {
     get(s"/${ UUID.randomUUID() }") {
       status shouldBe 404
+    }
+  }
+
+  it should "fail if a file within a bag cannot be found" in {
+    val itemId = "01000000-0000-0000-0000-000000000001/bag-info2.txt"
+    get(s"/$itemId", headers = Map("Accept" -> "text/plain")) {
+      status shouldBe 404
+      body shouldBe s"Item $itemId not found"
     }
   }
 }


### PR DESCRIPTION
Fixes EASY-1632

#### When applied it will...
*  return a 404 instead of a 500 when a item within a bag is not found
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

