### PR TITLE
EASY-1670 Command-line startup script: argumenten met spaties

### DIFF
--- a/src/main/assembly/dist/bin/easy-bag-store
+++ b/src/main/assembly/dist/bin/easy-bag-store
@@ -17,4 +17,4 @@ fi
 LC_ALL=en_US.UTF-8 \
 java -Dlogback.configurationFile=$LOGCONFIG \
      -Dapp.home=$APPHOME \
-     -jar $APPHOME/bin/easy-bag-store.jar $@
+     -jar $APPHOME/bin/easy-bag-store.jar "$@"


### PR DESCRIPTION
EASY-1670 Command-line startup script: argumenten met spaties

Fixes EASY-1670

#### When applied
* It is possible to pass parameters containing spaces

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
