### PR TITLE
EASY-1883: only add files to the ArchiveStream if the file(s) exist

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -174,9 +174,10 @@ trait BagStoreComponent {
             }
           }
           allEntries <- Try { (dirSpecs ++ fileSpecs).sortBy(_.entryPath) }
-          _ <- archiveStreamType.map { st =>
-            new ArchiveStream(st, allEntries).writeTo(outputStream)
-          }.getOrElse {
+          _ <- archiveStreamType.map(streamType => {
+            if (allEntries.isEmpty) Failure(NoSuchItemException(itemId))
+            else new ArchiveStream(streamType, allEntries).writeTo(outputStream)
+          }).getOrElse {
             if (allEntries.size == 1) Try {
               fileSystem.toRealLocation(fileIds.head)
                 .map(f = path => {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -189,15 +189,15 @@ trait BagStoreComponent {
     }
 
     private def copyToOutputStream(itemId: ItemId, fileIds: Seq[FileId], entriesCount: Int, outputStream: => OutputStream) = {
-      if (entriesCount == 0) Failure(NoSuchItemException(itemId))
-      else if (entriesCount == 1) {
-        fileSystem.toRealLocation(fileIds.head)
+      entriesCount match {
+        case 0 => Failure(NoSuchItemException(itemId))
+        case 1 => fileSystem.toRealLocation(fileIds.head)
           .map(path => {
             debug(s"Copying $path to outputstream")
             Files.copy(path, outputStream)
           })
+        case _ => Failure(NoRegularFileException(itemId))
       }
-      else Failure(NoRegularFileException(itemId))
     }
 
     private def validateThatFileIsActive(path: Path, itemId: ItemId): Try[Unit] = {


### PR DESCRIPTION
Fixes EASY-1883

#### When applied it will...
* check if there are files to be added to the `ArchiveStream`, before creating such stream; if not, return a `NoSuchItemException`; this fixes the 200/404 bug described in the issue

@DANS-KNAW/easy for review