### PR TITLE
EASY-1887 return 410 instead of a 409 or 500 when requesting inactive bag / prohibit requesting single items from inactive bag

### DIFF
--- a/docs/01_manual.md
+++ b/docs/01_manual.md
@@ -25,7 +25,7 @@ SYNOPSIS
                     | add [-m,--move] [-u,--uuid <uuid>] <bag>
                     | get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
                     | stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
-                    | enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] <bag-id>]
+                    | enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] [-i,--inactive] <bag-id>]
                     | locate [-f,--file-data-location] <item-id>
                     | deactivate <bag-id>
                     | reactivate <bag-id>
@@ -110,7 +110,7 @@ ARGUMENTS
     ---
     
     Subcommand: stream - Retrieves an item by streaming it to the standard output
-      -f, --format  <arg>   stream item packaged in this format (tar|zip)
+          --format  <arg>   stream item packaged in this format (tar|zip)
           --help            Show help message
     
      trailing arguments:

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -62,7 +62,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
       cmd.bagId.toOption
         .map(s => for {
           itemId <- ItemId.fromString(s)
-          files <- bagStores.enumFiles(itemId, !cmd.excludeDirectories(), bagStoreBaseDir)
+          files <- bagStores.enumFiles(itemId, !cmd.excludeDirectories(), bagStoreBaseDir, cmd.forceInactive())
         } yield files.foreach(println(_)))
         .getOrElse {
           val includeActive = cmd.all() || !cmd.inactive()

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -55,7 +55,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
     case Some(cmd @ commandLine.stream) =>
       for {
         itemId <- ItemId.fromString(cmd.itemId())
-        _ <- bagStores.copyToStream(itemId, cmd.format.toOption, Console.out, bagStoreBaseDir)
+        _ <- bagStores.copyToStream(itemId, cmd.format.toOption, Console.out, bagStoreBaseDir, cmd.forceInactive())
       } yield s"Retrieved item with item-id: $itemId to stream."
       // TODO: Also report from which bag store, as with get
     case Some(cmd @ commandLine.enum) =>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -118,7 +118,7 @@ trait CommandLineOptionsComponent {
 
     val stream = new Subcommand("stream") {
       descr("Retrieves an item by streaming it to the standard output")
-      val format: ScallopOption[ArchiveStreamType] = opt(name = "format",
+      val format: ScallopOption[ArchiveStreamType] = opt(name = "format", noshort = true,
         descr = "stream item packaged in this format (tar|zip)")
       val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -46,7 +46,7 @@ trait CommandLineOptionsComponent {
          |${ _________ }| list
          |${ _________ }| add [-m,--move] [-u,--uuid <uuid>] <bag>
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
-         |${ _________ }| stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
+         |${ _________ }| stream [--force-inactive] [-f,--format zip|tar] <item-id>
          |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
          |${ _________ }| deactivate <bag-id>
@@ -95,7 +95,7 @@ trait CommandLineOptionsComponent {
       val uuid: ScallopOption[UUID] = opt(name = "uuid", short = 'u',
         descr = "UUID to use as bag-id for the bag",
         required = false)
-      val move: ScallopOption[Boolean] = opt(name = "move",
+      val move: ScallopOption[Boolean] = opt(name = "move", short = 'm',
         descr = "move (rather than copy) the bag when adding it to the bag store")
       footer(SUBCOMMAND_SEPARATOR)
     }
@@ -105,9 +105,9 @@ trait CommandLineOptionsComponent {
       descr("Retrieves an item by copying it to the specified directory (default: current directory).")
       val skipCompletion: ScallopOption[Boolean] = opt(name = "skip-completion",
         descr = "do not complete an incomplete bag")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive",
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
-      val outputDir: ScallopOption[Path] = opt(name = "directory",
+      val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
         descr = "directory in which to put the item",
         default = Some(Paths.get(".")))
       val itemId: ScallopOption[String] = trailArg[String](name = "item-id",
@@ -118,9 +118,9 @@ trait CommandLineOptionsComponent {
 
     val stream = new Subcommand("stream") {
       descr("Retrieves an item by streaming it to the standard output")
-      val format: ScallopOption[ArchiveStreamType] = opt(name = "format",
+      val format: ScallopOption[ArchiveStreamType] = opt(name = "format", short = 'f',
         descr = "stream item packaged in this format (tar|zip)")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive",
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", //TODO no short since f is reserved for format?
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
       val itemId: ScallopOption[String] = trailArg[String](name = "item-id",
         descr = "item-id of the item to stream")
@@ -134,9 +134,9 @@ trait CommandLineOptionsComponent {
         descr = "only enumerate inactive bags")
       val all: ScallopOption[Boolean] = opt[Boolean](name = "all", short = 'a',
         descr = "enumerate all bags, including inactive ones")
-      val excludeDirectories: ScallopOption[Boolean] = opt(name = "exclude-directories",
+      val excludeDirectories: ScallopOption[Boolean] = opt(name = "exclude-directories", short = 'e',
         descr = "enumerate only regular files, not directories")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive",
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
       val bagId: ScallopOption[String] = trailArg[String](name = "<bagId>",
         descr = "bag of which to enumerate the Files",

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -47,7 +47,7 @@ trait CommandLineOptionsComponent {
          |${ _________ }| add [-m,--move] [-u,--uuid <uuid>] <bag>
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
          |${ _________ }| stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
-         |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] <bag-id>]
+         |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
          |${ _________ }| deactivate <bag-id>
          |${ _________ }| reactivate <bag-id>
@@ -136,6 +136,8 @@ trait CommandLineOptionsComponent {
         descr = "enumerate all bags, including inactive ones")
       val excludeDirectories: ScallopOption[Boolean] = opt(name = "exclude-directories",
         descr = "enumerate only regular files, not directories")
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive",
+        descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
       val bagId: ScallopOption[String] = trailArg[String](name = "<bagId>",
         descr = "bag of which to enumerate the Files",
         required = false)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -46,7 +46,7 @@ trait CommandLineOptionsComponent {
          |${ _________ }| list
          |${ _________ }| add [-m,--move] [-u,--uuid <uuid>] <bag>
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
-         |${ _________ }| stream [--force-inactive] [-f,--format zip|tar] <item-id>
+         |${ _________ }| stream [-f, --force-inactive] [--format zip|tar] <item-id>
          |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
          |${ _________ }| deactivate <bag-id>
@@ -118,9 +118,9 @@ trait CommandLineOptionsComponent {
 
     val stream = new Subcommand("stream") {
       descr("Retrieves an item by streaming it to the standard output")
-      val format: ScallopOption[ArchiveStreamType] = opt(name = "format", short = 'f',
+      val format: ScallopOption[ArchiveStreamType] = opt(name = "format",
         descr = "stream item packaged in this format (tar|zip)")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", //TODO no short since f is reserved for format?
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
       val itemId: ScallopOption[String] = trailArg[String](name = "item-id",
         descr = "item-id of the item to stream")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -193,7 +193,7 @@ trait BagStoreComponent {
       new ArchiveStream(archiveStreamType, entries()).writeTo(outputStream)
     }
 
-    private def copyToOutputStream(itemId: ItemId, fileIds: Seq[FileId], entriesCount: Int, outputStream: => OutputStream) : Try[Long] = {
+    private def copyToOutputStream(itemId: ItemId, fileIds: Seq[FileId], entriesCount: Int, outputStream: => OutputStream): Try[Unit] = {
       entriesCount match {
         case 0 => Failure(NoSuchItemException(itemId))
         case 1 => fileSystem.toRealLocation(fileIds.head)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -173,9 +173,9 @@ trait BagStoreComponent {
       }
     }
 
-    private def fileIsFound(entriesCount: Int, itemId: ItemId): Try[Unit] = {
-      if (entriesCount == 0) Failure(NoSuchItemException(itemId))
-      else Success(())
+    private def fileIsFound(entriesCount: Int, itemId: ItemId): Try[Unit] = Try {
+      if (entriesCount == 0)
+        throw NoSuchItemException(itemId)
     }
 
     private def createFileSpecs(bagDir: BaseDir, itemPath: BaseDir, fileIds: Seq[FileId]): Try[Seq[EntrySpec]] = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -189,7 +189,7 @@ trait BagStoreComponent {
       fileIds.collect { case fileId if fileId.isDirectory => createEntrySpec(None, bagDir, itemPath, fileId) }
     }
 
-    private def copyToArchiveStream(itemId: ItemId, outputStream: => OutputStream)(entries: () => Seq[EntrySpec])(archiveStreamType: ArchiveStreamType) = {
+    private def copyToArchiveStream(itemId: ItemId, outputStream: => OutputStream)(entries: () => Seq[EntrySpec])(archiveStreamType: ArchiveStreamType) : Try[Unit] = {
       new ArchiveStream(archiveStreamType, entries()).writeTo(outputStream)
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -77,12 +77,12 @@ trait BagStoresComponent {
         }
     }
 
-    def enumFiles(itemId: ItemId, includeDirectories: Boolean = true, fromStore: Option[BaseDir] = None): Try[Seq[FileId]] = {
+    def enumFiles(itemId: ItemId, includeDirectories: Boolean = true, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Seq[FileId]] = {
       fromStore
-        .map(BagStore(_).enumFiles(itemId, includeDirectories))
+        .map(BagStore(_).enumFiles(itemId, includeDirectories, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).enumFiles(itemId, includeDirectories))
+            .map(BagStore(_).enumFiles(itemId, includeDirectories, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -52,12 +52,12 @@ trait BagStoresComponent {
         }
     }
 
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None): Try[Unit] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
       fromStore
-        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
+        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream))
+            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -45,7 +45,7 @@ package object bagstore {
   case class NoFileIdException(itemId: ItemId) extends Exception(s"item-id $itemId is not a file-id")
   case class CorruptBagStoreException(reason: String) extends Exception(s"BagStore seems to be corrupt: $reason")
   case class OutputAlreadyExists(path: Path) extends Exception(s"Output path already exists; not overwriting $path")
-  case class InactiveException(itemId: ItemId, forceInactive: Boolean) extends Exception(s"Tried to retrieve an inactive bag: ${ itemId.uuid } with toggle forceInactive = $forceInactive")
+  case class InactiveException(itemId: ItemId, forceInactive: Boolean = false) extends Exception(s"Tried to retrieve an inactive bag: ${ itemId.uuid } with toggle forceInactive = $forceInactive")
   case class OutputNotADirectoryException(path: Path) extends Exception(s"Output path must be a directory; $path exists, but is not a directory.")
   case class NoBagException(cause: Throwable) extends Exception("The provided input did not contain a bag", cause)
   case class InvalidBagException(bagId: BagId, msg: String) extends Exception(s"Bag $bagId is not a valid bag: $msg")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -75,14 +75,14 @@ trait BagsServletComponent extends DebugEnhancedLogging {
       val uuidStr = params("uuid")
       (multiParams("splat") match {
         case Seq(path) =>
-          ItemId
-            .fromString(s"""$uuidStr/${ path }""")
+          ItemId.fromString(s"""$uuidStr/${ path }""")
             .recoverWith {
               case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
-            }.flatMap(itemId => {
-            debug(s"Retrieving item $itemId")
-            bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType), response.outputStream)
-          })
+            }
+            .flatMap(itemId => {
+              debug(s"Retrieving item $itemId")
+              bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType), response.outputStream)
+            })
             .map(_ => Ok())
             .getOrRecover {
               case e: IllegalArgumentException => BadRequest(e.getMessage)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -80,9 +80,9 @@ trait BagsServletComponent extends DebugEnhancedLogging {
             .recoverWith {
               case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
             }.flatMap(itemId => {
-              debug(s"Retrieving item $itemId")
-              bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType) , response.outputStream)
-            })
+            debug(s"Retrieving item $itemId")
+            bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType), response.outputStream)
+          })
             .map(_ => Ok())
             .getOrRecover {
               case e: IllegalArgumentException => BadRequest(e.getMessage)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -97,7 +97,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
           })
           .getOrRecover {
             case e: NoBagIdException => InternalServerError(e.getMessage)
-            case e: InactiveException => Conflict(e.getMessage)
+            case e: InactiveException => Gone(e.getMessage)
             case e: IllegalArgumentException => BadRequest(e.getMessage)
             case e: NoRegularFileException => BadRequest(e.getMessage)
             case e: NoSuchItemException => NotFound(e.getMessage)
@@ -132,6 +132,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
                 case e: NoSuchItemException => NotFound(e.getMessage)
                 case e: NoSuchBagException => NotFound(e.getMessage)
                 case e: NoSuchFileItemException => NotFound(e.getMessage)
+                case e: InactiveException => Gone(e.getMessage)
                 case NonFatal(e) =>
                   logger.error("Error retrieving bag", e)
                   InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -306,7 +306,7 @@ class BagStoresSpec extends TestSupportFixture
     }
   }
 
-  "copyToStream" should "a stream containing the content of the files" in {
+  "copyToStream" should "return a stream containing the content of the files" in {
     implicit val baseDir: BaseDir = store1
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     val baos = new ByteArrayOutputStream()

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -228,6 +228,24 @@ class BagStoresSpec extends TestSupportFixture
     }
   }
 
+  it should "fail if the bag was marked as inactive" in {
+    implicit val baseDir: BaseDir = bagStore1.baseDir
+    bagStore1.add(testBagMinimal) should matchPattern {
+      case Success(bagId: BagId) if
+      bagStore1.deactivate(bagId).isSuccess &&
+        bagStore1.enumFiles(bagId).equals(Failure(InactiveException(bagId, false))) =>
+    }
+  }
+
+  it should "not if the bag was marked as inactive, when forceActive = true" in {
+    implicit val baseDir: BaseDir = bagStore1.baseDir
+    bagStore1.add(testBagMinimal) should matchPattern {
+      case Success(bagId: BagId) if
+      bagStore1.deactivate(bagId).isSuccess &&
+        bagStore1.enumFiles(bagId, forceInactive = true).isSuccess =>
+    }
+  }
+
   /*
    * If there are multiple payload manifests the BagIt specs do not require that they all contain ALL the payload files. Therefore, it is possible that
    * there are two payload manifests, each of contains a part of the payload file paths. The enum operation should still handle this correctly. The

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -140,8 +140,8 @@ class BagStoresSpec extends TestSupportFixture
   }
 
   it should "return empty stream if BagStore is empty" in {
-    inside(bagStores.enumBags().map(_.toList)) {
-      case Success(bagIds) => bagIds shouldBe empty
+    bagStores.enumBags().map(_.toList) should matchPattern {
+      case Success(bagIds: List[_]) if bagIds.isEmpty  =>
     }
   }
 
@@ -233,7 +233,7 @@ class BagStoresSpec extends TestSupportFixture
     bagStore1.add(testBagMinimal) should matchPattern {
       case Success(bagId: BagId) if
       bagStore1.deactivate(bagId).isSuccess &&
-        bagStore1.enumFiles(bagId).equals(Failure(InactiveException(bagId, false))) =>
+        bagStore1.enumFiles(bagId).equals(Failure(InactiveException(bagId))) =>
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -140,8 +140,8 @@ class BagStoresSpec extends TestSupportFixture
   }
 
   it should "return empty stream if BagStore is empty" in {
-    bagStores.enumBags().map(_.toList) should matchPattern {
-      case Success(bagIds: List[_]) if bagIds.isEmpty  =>
+    bagStores.enumBags() should matchPattern {
+      case Success(Seq()) =>
     }
   }
 
@@ -230,19 +230,21 @@ class BagStoresSpec extends TestSupportFixture
 
   it should "fail if the bag was marked as inactive" in {
     implicit val baseDir: BaseDir = bagStore1.baseDir
-    bagStore1.add(testBagMinimal) should matchPattern {
-      case Success(bagId: BagId) if
-      bagStore1.deactivate(bagId).isSuccess &&
-        bagStore1.enumFiles(bagId).equals(Failure(InactiveException(bagId))) =>
+    inside(bagStore1.add(testBagMinimal)) {
+      case Success(bagId: BagId) =>
+        bagStore1.deactivate(bagId) shouldBe a[Success[_]]
+        bagStore1.enumFiles(bagId) should matchPattern {
+          case Failure(InactiveException(`bagId`, false)) =>
+        }
     }
   }
 
   it should "not if the bag was marked as inactive, when forceActive = true" in {
     implicit val baseDir: BaseDir = bagStore1.baseDir
-    bagStore1.add(testBagMinimal) should matchPattern {
-      case Success(bagId: BagId) if
-      bagStore1.deactivate(bagId).isSuccess &&
-        bagStore1.enumFiles(bagId, forceInactive = true).isSuccess =>
+    inside(bagStore1.add(testBagMinimal)) {
+      case Success(bagId: BagId) =>
+        bagStore1.deactivate(bagId) shouldBe a[Success[_]]
+        bagStore1.enumFiles(bagId, forceInactive = true) shouldBe a[Success[_]]
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -329,8 +329,7 @@ class BagStoresSpec extends TestSupportFixture
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     bagStores.deactivate(bagID) shouldBe a[Success[_]]
     val baos = new ByteArrayOutputStream()
-    val forceInactive = true // explicit declared for clarity
-    bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir), forceInactive) shouldBe a[Success[_]]
+    bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir), forceInactive = true) shouldBe a[Success[_]]
     val content = baos.toString
     content should include("9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt")
     content should include("ae4573c51c28ac09546cd7fc55422ae4  manifest-md5.txt")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -15,7 +15,7 @@
  */
 package nl.knaw.dans.easy.bagstore.component
 
-import java.io.{ ByteArrayOutputStream, PrintStream, StringWriter }
+import java.io.ByteArrayOutputStream
 import java.nio.file.{ Files, Paths }
 
 import nl.knaw.dans.easy.bagstore._

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -292,12 +292,7 @@ class BagStoresSpec extends TestSupportFixture
     implicit val baseDir: BaseDir = store1
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    try {
-      bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir)) shouldBe a[Success[_]]
-    } finally {
-      ps.close()
-    }
+    bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir)) shouldBe a[Success[_]]
     val content = baos.toString
     content should include("9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt")
     content should include("ae4573c51c28ac09546cd7fc55422ae4  manifest-md5.txt")
@@ -308,12 +303,7 @@ class BagStoresSpec extends TestSupportFixture
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     bagStores.deactivate(bagID) shouldBe a[Success[_]]
     val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    try {
-      bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir)) shouldBe Failure(InactiveException(bagID))
-    } finally {
-      ps.close()
-    }
+    bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir)) shouldBe Failure(InactiveException(bagID))
   }
 
   it should "a stream containing the content of the files if the bag is made inactive beforehand, but the forceInactive param is given" in {
@@ -321,13 +311,8 @@ class BagStoresSpec extends TestSupportFixture
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     bagStores.deactivate(bagID) shouldBe a[Success[_]]
     val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    val forceInactive = true // explicitly declared for clarity
-    try {
-      bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir), forceInactive) shouldBe a[Success[_]]
-    } finally {
-      ps.close()
-    }
+    val forceInactive = true // explicit declared for clarity
+    bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir), forceInactive) shouldBe a[Success[_]]
     val content = baos.toString
     content should include("9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt")
     content should include("ae4573c51c28ac09546cd7fc55422ae4  manifest-md5.txt")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -306,7 +306,7 @@ class BagStoresSpec extends TestSupportFixture
     bagStores.copyToStream(bagID, Some(ArchiveStreamType.TAR), baos, Some(baseDir)) shouldBe Failure(InactiveException(bagID))
   }
 
-  it should "a stream containing the content of the files if the bag is made inactive beforehand, but the forceInactive param is given" in {
+  it should "return a stream containing the content of all the files if the bag is made inactive beforehand, but the forceInactive param is given" in {
     implicit val baseDir: BaseDir = store1
     val bagID = bagStore1.add(testBagMinimal).getOrElse(fail())
     bagStores.deactivate(bagID) shouldBe a[Success[_]]

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -214,7 +214,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID") {
       status shouldBe 410
-      body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
+      body shouldBe s"Tried to retrieve an inactive bag: $bagID with toggle forceInactive = false"
     }
   }
 
@@ -223,7 +223,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID/bag-info.txt") {
       status shouldBe 410
-      body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
+      body shouldBe s"Tried to retrieve an inactive bag: $bagID with toggle forceInactive = false"
     }
   }
 
@@ -232,7 +232,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID/bag-info6.txt") {
       status shouldBe 404
-      body.lines.mkString should include(s"Item $bagID/bag-info6.txt not found")
+      body shouldBe s"Item $bagID/bag-info6.txt not found"
     }
   }
 
@@ -242,6 +242,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 410
+      body shouldBe s"Tried to retrieve an inactive bag: $bagID with toggle forceInactive = false"
     }
   }
 
@@ -251,6 +252,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID/bag-info2.txt", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 404
+      body shouldBe s"Item $bagID/bag-info2.txt not found"
     }
   }
 
@@ -259,7 +261,7 @@ class BagsServletSpec extends TestSupportFixture
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID/bag-info.txt", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 410
-      body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
+      body shouldBe s"Tried to retrieve an inactive bag: $bagID with toggle forceInactive = false"
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -18,8 +18,8 @@ package nl.knaw.dans.easy.bagstore.server
 import java.nio.file.{ Files, Paths }
 import java.util.UUID
 
-import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
 import nl.knaw.dans.easy.bagstore._
+import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
 import org.apache.commons.io.FileUtils
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
@@ -230,7 +230,6 @@ class BagsServletSpec extends TestSupportFixture
 
   //TODO are these two cases below correct?
   // this calls enumFiles
-
   it should "not fail when done on an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -236,17 +236,24 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
-  //TODO are these two cases below correct?
   // this calls enumFiles
-  it should "not fail when done on an inactive/ hidden bag when headers text/plain is provided" in {
+  it should " fail when done on an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID", headers = Map("Accept" -> "text/plain")) {
-      status shouldBe 200
+      status shouldBe 410
     }
   }
 
   // this calls copyOutputStream
+  it should "fail, returning a 404, when done on non existing item in an inactive/ hidden bag when headers text/plain is provided" in {
+    val bagID = "01000000-0000-0000-0000-000000000001"
+    bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
+    get(s"/$bagID/bag-info2.txt", headers = Map("Accept" -> "text/plain")) {
+      status shouldBe 404
+    }
+  }
+
   it should "fail when done on an item in an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -213,18 +213,26 @@ class BagsServletSpec extends TestSupportFixture
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID") {
-      println(body)
       status shouldBe 410
       body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
     }
   }
 
-  it should "fail when done on an item within an inactive/ hidden bag" in {
+  it should "fail, returning a 410, when done on an item within an inactive/ hidden bag" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
-    get(s"/$bagID/bag-info2.txt") {
+    get(s"/$bagID/bag-info.txt") {
       status shouldBe 410
       body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
+    }
+  }
+
+  it should "return a 404 non-existing item within an inactive/ hidden bag is requested" in {
+    val bagID = "01000000-0000-0000-0000-000000000001"
+    bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
+    get(s"/$bagID/bag-info6.txt") {
+      status shouldBe 404
+      body.lines.mkString should include(s"Item $bagID/bag-info6.txt not found")
     }
   }
 
@@ -242,7 +250,7 @@ class BagsServletSpec extends TestSupportFixture
   it should "fail when done on an item in an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
-    get(s"/$bagID/bag-info2.txt", headers = Map("Accept" -> "text/plain")) {
+    get(s"/$bagID/bag-info.txt", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 410
       body.lines.mkString should include(s"Tried to retrieve an inactive bag: $bagID")
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -229,6 +229,8 @@ class BagsServletSpec extends TestSupportFixture
   }
 
   //TODO are these two cases below correct?
+  // this calls enumFiles
+
   it should "not fail when done on an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
@@ -237,7 +239,8 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
-  it should "not when done on an item in an inactive/ hidden bag even when headers text/plain is provided" in {
+  // this calls copyOutputStream
+  it should "fail when done on an item in an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"
     bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
     get(s"/$bagID/bag-info2.txt", headers = Map("Accept" -> "text/plain")) {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -344,7 +344,7 @@ class StoresServletSpec extends TestSupportFixture
     bagStore1.deactivate(bagId) shouldBe a[Success[_]]
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 410
-      body shouldBe InactiveException(bagId, forceInactive = false).getMessage
+      body shouldBe InactiveException(bagId).getMessage
     }
   }
 
@@ -353,7 +353,7 @@ class StoresServletSpec extends TestSupportFixture
     bagStore1.deactivate(bagId) shouldBe a[Success[_]]
     get(s"/store1/bags/${ bagId }/data/y", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 410
-      body shouldBe InactiveException(bagId, forceInactive = false).getMessage
+      body shouldBe InactiveException(bagId).getMessage
     }
   }
 
@@ -381,14 +381,15 @@ class StoresServletSpec extends TestSupportFixture
     putBag(uuid, testBagUnprunedA)
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), basicAuthentication) {
       status shouldBe 400
-      body should include(s"$uuid already exists in BagStore store1 (bag-ids must be globally unique)")
+      body shouldBe s"$uuid already exists in BagStore store1 (bag-ids must be globally unique)"
     }
-  } 
-  
+  }
+
   it should "should fail and return a badrequest if there are multiple files in the root directory of the zipped bag" in {
     val uuid = "11111111-1111-1111-1111-111111111114"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedInvalid), basicAuthentication)  {
-        status shouldBe 400
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedInvalid), basicAuthentication) {
+      status shouldBe 400
+      body shouldBe "There must be exactly one file in the root directory of the zipped bag, found 2"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -339,11 +339,20 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "fail when an inactive bag is requested with the wrong queryParams" in {
+  it should "fail when an inactive bag is requested" in {
     val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
     bagStore1.deactivate(bagId) shouldBe a[Success[_]]
     get(s"/store1/bags/${ bagId }", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
-      status shouldBe 409
+      status shouldBe 410
+      body shouldBe InactiveException(bagId, forceInactive = false).getMessage
+    }
+  }
+
+  it should "fail when an item from an inactive bag is requested" in {
+    val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
+    bagStore1.deactivate(bagId) shouldBe a[Success[_]]
+    get(s"/store1/bags/${ bagId }/bag-revision-1/metadata/files.xml", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
+      status shouldBe 410
       body shouldBe InactiveException(bagId, forceInactive = false).getMessage
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -351,7 +351,7 @@ class StoresServletSpec extends TestSupportFixture
   it should "fail when an item from an inactive bag is requested" in {
     val bagId = BagId(UUID.fromString("01000000-0000-0000-0000-000000000001"))
     bagStore1.deactivate(bagId) shouldBe a[Success[_]]
-    get(s"/store1/bags/${ bagId }/bag-revision-1/metadata/files.xml", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
+    get(s"/store1/bags/${ bagId }/data/y", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
       status shouldBe 410
       body shouldBe InactiveException(bagId, forceInactive = false).getMessage
     }


### PR DESCRIPTION
Fixes EASY-1887

- [x]  merge with PR #81 first
- [x] Resolve merge conflicts

**It does not work for all paths leading to the enum function. So you can still get a list of the files in an inactive bag (but you can't get the content as text or zip).**
 

#### When applied it will...
* return a 410 instead of  500 when a hidden bag is requested trough bagsServletComponent
* return a 410 instead of 409 when a hidden bag is requested through bagStoreServletComponent
* prohibit to request individual items from an inactive bag through http
* prohibit to request individual items from an inactive bag through the stream command line option (unless the forceInactive param is supplied)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

steps

start deasy

ensure the latest version of easy-bag-store is built and deployed

ingest a bag to the bag store

connect to the deasy VM via SSH

set the bag to inactive using the CLI: easy-bag-store deactivate <bag-id>

run curl -v -H 'accept: application/zip' 'http://localhost:20110/bags/<bag-id>' to confirm the first problem

run curl -v -H 'accept: text/plain' 'http://localhost:20110/bags/<bag-id>/bagit.txt' to confirm the second problem

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-bag-store                   | [PR#77](https://github.com/DANS-KNAW/easy-bag-store/pull/77) 