### PR TITLE
EASY-1890  logging writes non alpha-numeric data to the log

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/ServletEnhancedLogging.scala
@@ -31,7 +31,7 @@ trait ServletEnhancedLogging extends DebugEnhancedLogging {
       case(key,value) if key.toLowerCase.endsWith("authorization") => (key,"*****")
       case keyValue => keyValue
     }
-    logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$params headers=$headers")
+    logger.info(s"${ request.getMethod } ${ request.getRequestURL } remote=${ request.getRemoteAddr } params=$multiParams headers=$headers")
   }
 }
 object ServletEnhancedLogging extends DebugEnhancedLogging {


### PR DESCRIPTION
Fixes EASY-1890  logging writes non alpha-numeric data to the log

#### When applied it will...
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [ ] Upload a zipped bag to the store via the easy-bag-store service.

But how? Anyway, the curl commands documented under [test-resources#put-requests](https://github.com/DANS-KNAW/easy-test-resources/blob/master/test-run/EASY-1583-bag-store/EASY-1583-bag-store.md#put-requests)
needed credentials configured on deasy in `/etc/opt/dans.knaw.nl/easy-bag-store/application.properties`. Neither `PUT bag.zip using --data-binary` nor `PUT bag.zip using -T` with `easy-test-resources/test-data/bags/base-bag.zip` reproduced the problem.

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
