### PR TITLE
Return a bad request instead of internal server error when an empty reflag.txt is put

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
@@ -20,7 +20,7 @@ import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermission }
 import java.nio.file.{ FileVisitResult, FileVisitor, Files, Path }
-import java.util.{ UUID, Set => JSet }
+import java.util.{ Set => JSet }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.exception.ZipException
@@ -188,7 +188,7 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
           _ = Files.deleteIfExists(tempRefbags)
           _ = Files.move(refbags, tempRefbags)
           _ = assert(!Files.exists(refbags), s"$refbags should have been moved to $tempRefbags, however, it appears to still be present here")
-          _ <-  // remove refbags.txt from all tagmanifests (if it was present there)
+          _ <- // remove refbags.txt from all tagmanifests (if it was present there)
             bagFacade.removeFromTagManifests(bagDir, "refbags.txt")
         } yield Some(tempRefbags)
       }
@@ -268,7 +268,7 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
   }
   private def assertRefbagsFileIsNotEmpty(bagId: BagId, refbags: Path): Try[Unit] = Try {
     if (managed(Source.fromFile(refbags.toFile)).acquireAndGet(_.mkString.trim.isEmpty)) {
-      throw InvalidBagException(bagId,"the bag contains an empty refbags.txt")
+      throw InvalidBagException(bagId, "the bag contains an empty refbags.txt")
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
@@ -188,8 +188,8 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
           _ = Files.deleteIfExists(tempRefbags)
           _ = Files.move(refbags, tempRefbags)
           _ = assert(!Files.exists(refbags), s"$refbags should have been moved to $tempRefbags, however, it appears to still be present here")
-          _ <- // remove refbags.txt from all tagmanifests (if it was present there)
-            bagFacade.removeFromTagManifests(bagDir, "refbags.txt")
+          // remove refbags.txt from all tagmanifests (if it was present there)
+          _ <- bagFacade.removeFromTagManifests(bagDir, "refbags.txt")
         } yield Some(tempRefbags)
       }
       else Success(None)
@@ -266,6 +266,7 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
       bagDirs.map(bagFacade.getSupportedManifestAlgorithms).collectResults.map(_.toSet)
     }
   }
+
   private def assertRefbagsFileIsNotEmpty(bagId: BagId, refbags: Path): Try[Unit] = Try {
     if (managed(Source.fromFile(refbags.toFile)).acquireAndGet(_.mkString.trim.isEmpty)) {
       throw InvalidBagException(bagId, "the bag contains an empty refbags.txt")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -217,7 +217,7 @@ trait BagStoreComponent {
           staging <- if (skipStage) Try { bagDir.getParent }
                      else bagProcessing.stageBagDir(bagDir)
           path = staging.resolve(bagDir.getFileName)
-          maybeRefbags <- bagProcessing.getReferenceBags(path, uuid)
+          maybeRefbags <- bagProcessing.getReferenceBags(path, bagId)
           _ = debug(s"refbags tempfile: $maybeRefbags")
           valid <- fileSystem.isVirtuallyValid(path).recover { case _: BagReaderException => Left("Could not read bag") }
           _ <- valid.fold(msg => Failure(InvalidBagException(bagId, msg)), _ => Success(()))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -217,7 +217,7 @@ trait BagStoreComponent {
           staging <- if (skipStage) Try { bagDir.getParent }
                      else bagProcessing.stageBagDir(bagDir)
           path = staging.resolve(bagDir.getFileName)
-          maybeRefbags <- bagProcessing.getReferenceBags(path)
+          maybeRefbags <- bagProcessing.getReferenceBags(path, uuid)
           _ = debug(s"refbags tempfile: $maybeRefbags")
           valid <- fileSystem.isVirtuallyValid(path).recover { case _: BagReaderException => Left("Could not read bag") }
           _ <- valid.fold(msg => Failure(InvalidBagException(bagId, msg)), _ => Success(()))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -162,10 +162,10 @@ trait StoresServletComponent extends DebugEnhancedLogging {
             )))
             .getOrRecover {
               case e: CompositeException if e.throwables.exists(_.isInstanceOf[IncorrectNumberOfFilesInBagZipRootException]) => BadRequest(e.getMessage())
+              case e: InvalidBagException => BadRequest(e.getMessage)
               case e: IllegalArgumentException => BadRequest(e.getMessage)
               case e: BagIdAlreadyAssignedException => BadRequest(e.getMessage)
               case e: NoBagException => BadRequest(e.getMessage)
-              case e: InvalidBagException => BadRequest(e.getMessage)
               case e: IncorrectNumberOfFilesInBagZipRootException => BadRequest(e.getMessage)
               case e =>
                 logger.error("Unexpected type of failure", e)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -162,10 +162,10 @@ trait StoresServletComponent extends DebugEnhancedLogging {
             )))
             .getOrRecover {
               case e: CompositeException if e.throwables.exists(_.isInstanceOf[IncorrectNumberOfFilesInBagZipRootException]) => BadRequest(e.getMessage())
-              case e: InvalidBagException => BadRequest(e.getMessage)
               case e: IllegalArgumentException => BadRequest(e.getMessage)
               case e: BagIdAlreadyAssignedException => BadRequest(e.getMessage)
               case e: NoBagException => BadRequest(e.getMessage)
+              case e: InvalidBagException => BadRequest(e.getMessage)
               case e: IncorrectNumberOfFilesInBagZipRootException => BadRequest(e.getMessage)
               case e =>
                 logger.error("Unexpected type of failure", e)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
@@ -224,7 +224,7 @@ class BagProcessingSpec extends BagProcessingFixture {
     val bagDir = makeBagDirForRefbagTests("                           ")
     val bagId = BagId(UUID.randomUUID())
     bagProcessing.getReferenceBags(bagDir.path, bagId) should matchPattern {
-      case Failure(e: InvalidBagException) if e == InvalidBagException(bagId, "the bag contains an empty refbags.txt") =>
+      case Failure(InvalidBagException(`bagId`, "the bag contains an empty refbags.txt")) =>
     }
   }
 
@@ -240,11 +240,9 @@ class BagProcessingSpec extends BagProcessingFixture {
     bagDir.clear()
 
     (bagDir / "refbags.txt")
-      .createFile()
       .write(content)
 
     (bagDir / "bagit.txt")
-      .createFile()
       .write(
         """BagIt-Version: 0.97
           |Tag-File-Character-Encoding: UTF-8""".stripMargin)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
@@ -29,7 +29,7 @@ import scala.io.Source
 import scala.util.{ Failure, Success }
 
 class BagProcessingSpec extends BagProcessingFixture
-with BeforeAndAfter {
+  with BeforeAndAfter {
 
   FileUtils.copyDirectory(
     Paths.get("src/test/resources/bags/basic-sequence-pruned").toFile,
@@ -53,7 +53,7 @@ with BeforeAndAfter {
   private val localBaseUri: URI = fileSystem.localBaseUri
   implicit val baseDir: BaseDir = bagStore.baseDir
 
-  override def beforeEach(): Unit =  {
+  override def beforeEach(): Unit = {
     val refBagDir = File(testDir.toString) / "refbag"
     refBagDir.createDirectories()
     refBagDir.clear()

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
@@ -204,7 +204,7 @@ class BagProcessingSpec extends BagProcessingFixture {
 
   "getReferenceBags" should "fail when an empty refbag.txt is found in the bag" in {
     // first create dir with empty refbag.txt
-    val bagDir = makeBagDirForRefbagText("")
+    val bagDir = makeBagDirForRefbagTests("")
 
     val bagId = BagId(UUID.randomUUID())
     bagProcessing.getReferenceBags(bagDir.path, bagId) should matchPattern {
@@ -221,7 +221,7 @@ class BagProcessingSpec extends BagProcessingFixture {
   }
 
   it should "fail when an refbag.txt with only whitespaces is found in the bag" in {
-    val bagDir = makeBagDirForRefbagText("                           ")
+    val bagDir = makeBagDirForRefbagTests("                           ")
     val bagId = BagId(UUID.randomUUID())
     bagProcessing.getReferenceBags(bagDir.path, bagId) should matchPattern {
       case Failure(e: InvalidBagException) if e == InvalidBagException(bagId, "the bag contains an empty refbags.txt") =>
@@ -229,12 +229,12 @@ class BagProcessingSpec extends BagProcessingFixture {
   }
 
   it should "succeed a non-empty refbag.txt is found in the bag" in {
-    val bagDir = makeBagDirForRefbagText("refbag content")
+    val bagDir = makeBagDirForRefbagTests("refbag content")
     val bagId = BagId(UUID.randomUUID())
     bagProcessing.getReferenceBags(bagDir.path, bagId) shouldBe a[Success[_]]
   }
 
-  private def makeBagDirForRefbagText(content: String): File = {
+  private def makeBagDirForRefbagTests(content: String): File = {
     val bagDir = File(testDir.toString) / "refbag"
     bagDir.createDirectories()
     bagDir.clear()

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -526,7 +526,7 @@ class StoresServletSpec extends TestSupportFixture
     val bagId = BagId(UUID.fromString(uuid))
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthentication) {
       status shouldBe 400
-      body should include(s"[$uuid] the bag contains an empty refbags.txt")
+      body should include(InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage)
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -28,6 +28,7 @@ import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreCo
 import org.apache.commons.io.FileUtils
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
+import resource.managed
 
 import scala.io.Source
 import scala.util.{ Success, Try }
@@ -543,12 +544,8 @@ class StoresServletSpec extends TestSupportFixture
 
   private def createZipWithInvalidOrEmptyRefBag(content: String) = {
     Files.createFile(testBagsUnpruned.resolve("a").resolve("refbags.txt"))
-    val pw = new PrintWriter(testBagsUnpruned.resolve("a").resolve("refbags.txt").toFile)
-    try {
-      pw.write(content)
-    } finally {
-      pw.close()
-    }
+    managed(new PrintWriter(testBagsUnpruned.resolve("a").resolve("refbags.txt").toFile))
+      .acquireAndGet(_.write(content))
     new ZipFile(testBagUnprunedEmptyRefBag.toFile) {
       addFolder(testBagsUnpruned.resolve("a").toFile, new ZipParameters)
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -526,7 +526,7 @@ class StoresServletSpec extends TestSupportFixture
     val bagId = BagId(UUID.fromString(uuid))
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthentication) {
       status shouldBe 400
-      body should include(InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage)
+      body shouldBe InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage
     }
   }
 
@@ -537,7 +537,7 @@ class StoresServletSpec extends TestSupportFixture
     val bagId = BagId(UUID.fromString(uuid))
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthentication) {
       status shouldBe 400
-      body should include(s"Invalid UUID string: $content")
+      body shouldBe s"Invalid UUID string: $content"
     }
   }
 


### PR DESCRIPTION
- [x] refine code

Fixes EASY-1892

#### When applied it will...
* Return a bad request instead of internal server error when an empty reflag.txt is put

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
start a deasy VM

copy the attached bag to the home dir of the vagrant user

execute the following command:

curl -X PUT -H 'Content-type: application/zip' 'http://localhost:20110/stores/easy/bags/00000000-0000-0000-0000-000000000010' --data-binary @badrefbags.zip -u easy-bag-store:easy_bag_store -v