### PR TITLE
EASY-1889 return a 415 when a wrong Content-Type is given.

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -216,6 +216,8 @@ paths:
             * The bag is not virtually-valid.
             * The bag contained a `refbags.txt` file but it contained no data, or malformed data or
               references to non-existent bags.
+        415:
+          description: The request did not contain the appropiate Content-Type header ('application/zip')
         503:
           description: |
             The server cannot fulfil the request because of a temporary situation. If possible, the

--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -217,7 +217,7 @@ paths:
             * The bag contained a `refbags.txt` file but it contained no data, or malformed data or
               references to non-existent bags.
         415:
-          description: The request did not contain the appropiate Content-Type header ('application/zip')
+          description: Unsupported media type
         503:
           description: |
             The server cannot fulfil the request because of a temporary situation. If possible, the

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -50,7 +50,7 @@ package object bagstore {
   case class NoBagException(cause: Throwable) extends Exception("The provided input did not contain a bag", cause)
   case class InvalidBagException(bagId: BagId, msg: String) extends Exception(s"Bag $bagId is not a valid bag: $msg")
   case class NoRegularFileException(itemId: ItemId) extends Exception(s"Item $itemId is not a regular file.")
-  case class UnsupportedMediaTypeException(givenType: String, acceptedType: String) extends Exception(s"media type $givenType is not supported by this api. Supported types are '$acceptedType'")
+  case class UnsupportedMediaTypeException(givenType: String, acceptedType: String) extends Exception(s"media type $givenType is not supported by this API. Supported types are '$acceptedType'")
 
   type BaseDir = Path
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -50,6 +50,7 @@ package object bagstore {
   case class NoBagException(cause: Throwable) extends Exception("The provided input did not contain a bag", cause)
   case class InvalidBagException(bagId: BagId, msg: String) extends Exception(s"Bag $bagId is not a valid bag: $msg")
   case class NoRegularFileException(itemId: ItemId) extends Exception(s"Item $itemId is not a regular file.")
+  case class UnsupportedMediaTypeException(givenType: String, acceptedType: String) extends Exception(s"media type $givenType is not supported by this api. Supported types are '$acceptedType'")
 
   type BaseDir = Path
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -181,7 +181,7 @@ trait StoresServletComponent extends DebugEnhancedLogging {
     }
   }
 
-  private def validateContentTypeHeader(requestContentType: Option[String], uuid: UUID) = {
+  private def validateContentTypeHeader(requestContentType: Option[String], uuid: UUID): Try[UUID] = {
     requestContentType.withFilter(_.equalsIgnoreCase("application/zip"))
       .map(_ => Success(uuid))
       .getOrElse(Failure(UnsupportedMediaTypeException(requestContentType.getOrElse("none"), "application/zip")))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -151,7 +151,6 @@ trait StoresServletComponent extends DebugEnhancedLogging {
       val bagStore = params("bagstore")
       val uuidStr = params("uuid")
       val requestContentType = Option(request.getHeader("Content-Type"))
-      logger.info(s"Received PUT request for bagstore $bagStore and UUID $uuidStr")
       bagStores.getBaseDirByShortname(bagStore)
         .map(base => {
           Try { UUID.fromString(uuidStr) }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -585,7 +585,9 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "fail, returning a 415 when an invalid content-type header is given" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), basicAuthentication ::: List(("Content-Type", "application/tar"))) {
+    put(s"/store1/bags/$uuid",
+      body = Files.readAllBytes(testBagUnprunedA),
+      headers = "Content-Type" -> "application/tar" :: basicAuthentication) {
       status shouldBe 415
       body shouldBe "media type application/tar is not supported by this api. Supported types are 'application/zip'"
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -354,7 +354,7 @@ class StoresServletSpec extends TestSupportFixture
   }
 
   def authenticationHeaderAndContentTypeZip(username: String, password: String): List[(String, String)] = {
-    authenticationHeader(username, password) ::: List(("Content-Type", "application/zip"))
+    authenticationHeader(username, password) :+ "Content-Type" -> "application/zip"
   }
 
   private val basicAuthentication = authenticationHeader(username, password)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -545,7 +545,7 @@ class StoresServletSpec extends TestSupportFixture
     val content = "invalid content"
     createZipWithInvalidOrEmptyRefBag(content)
     val uuid = "11111111-1121-1111-1111-111111111111"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag),headers =  basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe s"Invalid UUID string: $content"
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -369,7 +369,7 @@ class StoresServletSpec extends TestSupportFixture
   private val basicAuthenticationAndZipContentType = basicAuthentication  :+ "Content-Type" -> "application/zip"
 
   def putBag(uuid: String, bagZip: Path): Unit = {
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(bagZip), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(bagZip), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 201
       header should contain("Location" -> s"http://example-archive.org/stores/store1/bags/$uuid")
     }
@@ -383,7 +383,7 @@ class StoresServletSpec extends TestSupportFixture
   it should "fail, returning a bad request when a second put is done on the same uuid" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
     putBag(uuid, testBagUnprunedA)
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe s"$uuid already exists in BagStore store1 (bag-ids must be globally unique)"
     }
@@ -391,7 +391,7 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "should fail and return a badrequest if there are multiple files in the root directory of the zipped bag" in {
     val uuid = "11111111-1111-1111-1111-111111111114"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedInvalid), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedInvalid), headers = basicAuthenticationAndZipContentType) {
       body shouldBe "There must be exactly one file in the root directory of the zipped bag, found 2"
     }
   }
@@ -493,7 +493,7 @@ class StoresServletSpec extends TestSupportFixture
   }
 
   it should "fail when the store is unknown" in {
-    put("/unknown-store/bags/11111111-1111-1111-1111-111111111111", body = Files.readAllBytes(testBagUnprunedA), basicAuthenticationAndZipContentType) {
+    put("/unknown-store/bags/11111111-1111-1111-1111-111111111111", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 404
       body shouldBe "No such bag-store: unknown-store"
     }
@@ -501,7 +501,7 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "fail when the given uuid is not a uuid" in {
     val uuid = "11111111111111111111111111111111"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe s"invalid UUID string: $uuid"
     }
@@ -525,7 +525,7 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "fail when the input stream contains anything else than a zip-file" in {
     val uuid = "66666666-6666-6666-6666-666666666666"
-    put(s"/store1/bags/$uuid", body = "hello world".getBytes, basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = "hello world".getBytes, headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe "The provided input did not contain a bag"
     }
@@ -535,7 +535,7 @@ class StoresServletSpec extends TestSupportFixture
     createZipWithInvalidOrEmptyRefBag("")
     val uuid = "11111111-1111-1111-1111-111111111111"
     val bagId = BagId(UUID.fromString(uuid))
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage
     }
@@ -545,8 +545,7 @@ class StoresServletSpec extends TestSupportFixture
     val content = "invalid content"
     createZipWithInvalidOrEmptyRefBag(content)
     val uuid = "11111111-1121-1111-1111-111111111111"
-    val bagId = BagId(UUID.fromString(uuid))
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag),headers =  basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe s"Invalid UUID string: $content"
     }
@@ -569,7 +568,7 @@ class StoresServletSpec extends TestSupportFixture
     }
 
     val uuid = "66666666-6666-6666-6666-666666666666"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(zip), basicAuthenticationAndZipContentType) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(zip), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body should include(s"Bag $uuid is not a valid bag")
     }
@@ -577,7 +576,7 @@ class StoresServletSpec extends TestSupportFixture
 
   it should "fail, returning a 415 when no content-type header is given" in {
     val uuid = "11111111-1111-1111-1111-111111111111"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), basicAuthentication) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthentication) {
       status shouldBe 415
       body shouldBe "media type none is not supported by this api. Supported types are 'application/zip'"
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -365,12 +365,8 @@ class StoresServletSpec extends TestSupportFixture
     List("Authorization" -> s"$authType $encoded")
   }
 
-  def authenticationHeaderAndContentTypeZip(username: String, password: String): List[(String, String)] = {
-    authenticationHeader(username, password) :+ "Content-Type" -> "application/zip"
-  }
-
   private val basicAuthentication = authenticationHeader(username, password)
-  private val basicAuthenticationAndZipContentType = authenticationHeaderAndContentTypeZip(username, password)
+  private val basicAuthenticationAndZipContentType = basicAuthentication  :+ "Content-Type" -> "application/zip"
 
   def putBag(uuid: String, bagZip: Path): Unit = {
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(bagZip), basicAuthenticationAndZipContentType) {
@@ -539,7 +535,7 @@ class StoresServletSpec extends TestSupportFixture
     createZipWithInvalidOrEmptyRefBag("")
     val uuid = "11111111-1111-1111-1111-111111111111"
     val bagId = BagId(UUID.fromString(uuid))
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthentication) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage
     }
@@ -550,7 +546,7 @@ class StoresServletSpec extends TestSupportFixture
     createZipWithInvalidOrEmptyRefBag(content)
     val uuid = "11111111-1121-1111-1111-111111111111"
     val bagId = BagId(UUID.fromString(uuid))
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthentication) {
+    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe s"Invalid UUID string: $content"
     }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -578,7 +578,7 @@ class StoresServletSpec extends TestSupportFixture
     val uuid = "11111111-1111-1111-1111-111111111111"
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthentication) {
       status shouldBe 415
-      body shouldBe "media type none is not supported by this api. Supported types are 'application/zip'"
+      body shouldBe "media type none is not supported by this API. Supported types are 'application/zip'"
     }
   }
 
@@ -588,7 +588,7 @@ class StoresServletSpec extends TestSupportFixture
       body = Files.readAllBytes(testBagUnprunedA),
       headers = "Content-Type" -> "application/tar" :: basicAuthentication) {
       status shouldBe 415
-      body shouldBe "media type application/tar is not supported by this api. Supported types are 'application/zip'"
+      body shouldBe "media type application/tar is not supported by this API. Supported types are 'application/zip'"
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -366,7 +366,7 @@ class StoresServletSpec extends TestSupportFixture
   }
 
   private val basicAuthentication = authenticationHeader(username, password)
-  private val basicAuthenticationAndZipContentType = basicAuthentication  :+ "Content-Type" -> "application/zip"
+  private val basicAuthenticationAndZipContentType = "Content-Type" -> "application/zip" :: basicAuthentication
 
   def putBag(uuid: String, bagZip: Path): Unit = {
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(bagZip), basicAuthenticationAndZipContentType) {


### PR DESCRIPTION
- [x] case sensitivity
- [x] refine code

Fixes EASY-1889

#### When applied it will...
* return a 415 when a bag is put with another Content-Type than 'application/zip'
* 
#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 