### PR TITLE
EASY-2056: use new servlet-logging features from dans-scala-lib v1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreAuthenticationSupport.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagStoreAuthenticationSupport.scala
@@ -17,15 +17,10 @@ package nl.knaw.dans.easy.bagstore.server
 
 import javax.servlet.http.{ HttpServletRequest, HttpServletResponse }
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
-import nl.knaw.dans.lib.logging.servlet._
-import nl.knaw.dans.lib.logging.servlet.masked.MaskedAuthorizationHeader
 import org.scalatra.auth.strategy.BasicAuthStrategy.BasicAuthRequest
 import org.scalatra.{ BadRequest, ScalatraBase, Unauthorized }
 
-trait BagStoreAuthenticationSupport extends DebugEnhancedLogging
-  with ServletLogger
-  with MaskedAuthorizationHeader
-  with PlainLogFormatter {
+trait BagStoreAuthenticationSupport extends DebugEnhancedLogging {
   self: ScalatraBase =>
 
   def bagstoreUsername: String
@@ -46,12 +41,12 @@ trait BagStoreAuthenticationSupport extends DebugEnhancedLogging
 
   private def badRequest = {
     logger.info(s"${ request.getMethod } did not have basic authentication")
-    halt(BadRequest("Bad Request").logResponse)
+    halt(BadRequest("Bad Request"))
   }
 
   private def unauthenticated = {
     val headers = Map("WWW-Authenticate" -> s"""Basic realm="$realm"""")
-    halt(Unauthorized("Unauthenticated", headers).logResponse)
+    halt(Unauthorized("Unauthenticated", headers))
   }
 
   protected def validate(userName: String, password: String): Boolean = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -31,11 +31,11 @@ trait BagsServletComponent {
 
   val bagsServlet: BagsServlet
 
-  trait BagsServlet extends ScalatraServlet
+  trait BagsServlet extends ScalatraServlet with ServletUtils
     with ServletLogger
-    with MaskedAuthorizationHeader
     with PlainLogFormatter
-    with ServletUtils {
+    with MaskedAuthorizationHeader
+    with LogResponseBodyOnError {
 
     get("/") {
       contentType = "text/plain"
@@ -45,7 +45,7 @@ trait BagsServletComponent {
         .getOrRecover(e => {
           logger.error("Unexpected type of failure", e)
           InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-        }).logResponse
+        })
     }
 
     get("/:uuid") {
@@ -72,12 +72,12 @@ trait BagsServletComponent {
           case e =>
             logger.error("Unexpected type of failure", e)
             InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-        }.logResponse
+        }
     }
 
     get("/:uuid/*") {
       val uuidStr = params("uuid")
-      (multiParams("splat") match {
+      multiParams("splat") match {
         case Seq(path) =>
           ItemId.fromString(s"""$uuidStr/${ path }""")
             .recoverWith {
@@ -102,7 +102,7 @@ trait BagsServletComponent {
         case p =>
           logger.error(s"Unexpected path: $p")
           InternalServerError("Unexpected path")
-      }).logResponse
+      }
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/DefaultServletComponent.scala
@@ -29,10 +29,11 @@ trait DefaultServletComponent {
   val defaultServlet: DefaultServlet
 
   trait DefaultServlet extends ScalatraServlet
-    with DebugEnhancedLogging
     with ServletLogger
+    with PlainLogFormatter
     with MaskedAuthorizationHeader
-    with PlainLogFormatter {
+    with LogResponseBodyOnError
+    with DebugEnhancedLogging {
     val externalBaseUri: URI
     val version: String
 
@@ -42,7 +43,7 @@ trait DefaultServletComponent {
         s"""EASY Bag Store is running v$version.
            |Available stores at <${ externalBaseUri.resolve("stores") }>
            |Bags from all stores at <${ externalBaseUri.resolve("bags") }>
-           |""".stripMargin).logResponse
+           |""".stripMargin)
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -39,7 +39,8 @@ trait StoresServletComponent {
     with BagStoreAuthenticationSupport
     with ServletLogger
     with PlainLogFormatter
-    with MaskedAuthorizationHeader {
+    with MaskedAuthorizationHeader
+    with LogResponseBodyOnError {
 
     val externalBaseUri: URI
 
@@ -49,7 +50,7 @@ trait StoresServletComponent {
         .keys
         .map(store => s"<${ externalBaseUri.resolve(s"stores/$store") }>")
         .mkString("\n")
-      ).logResponse
+      )
     }
 
     get("/:bagstore") {
@@ -62,7 +63,6 @@ trait StoresServletComponent {
              |""".stripMargin
         })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
-        .logResponse
     }
 
     get("/:bagstore/bags") {
@@ -78,7 +78,6 @@ trait StoresServletComponent {
             })
         })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
-        .logResponse
     }
 
     get("/:bagstore/bags/:uuid") {
@@ -113,13 +112,12 @@ trait StoresServletComponent {
               InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
           })
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
-        .logResponse
     }
 
     get("/:bagstore/bags/:uuid/*") {
       val bagstore = params("bagstore")
       val uuidStr = params("uuid")
-      (multiParams("splat") match {
+      multiParams("splat") match {
         case Seq(path) =>
           bagStores.getBaseDirByShortname(bagstore)
             .map(baseDir => ItemId.fromString(s"""$uuidStr/${ path }""")
@@ -146,7 +144,7 @@ trait StoresServletComponent {
         case p =>
           logger.error(s"Unexpected path: $p")
           InternalServerError("Unexpected path")
-      }).logResponse
+      }
     }
 
     put("/:bagstore/bags/:uuid") {
@@ -181,7 +179,6 @@ trait StoresServletComponent {
             }
         })
         .getOrElse(NotFound(s"No such bag-store: $bagStore"))
-        .logResponse
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2056

#### When applied it will
* no longer use `.logResponse` to log the servlet response
* add `LogResponseBodyOnError` trait to servlet definition

@DANS-KNAW/easy for review