### PR TITLE
EASY-2021 Corrigeer aanroepen van bag-store op nieuwe percent-encoding regels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -19,9 +19,7 @@ import java.net.URLDecoder
 import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
-import com.google.common.net.UrlEscapers
-
-import scala.collection.JavaConverters._
+import nl.knaw.dans.lib.encode.PathEncoding
 import scala.util.{ Failure, Success, Try }
 
 abstract class ItemId(val uuid: UUID) {
@@ -60,10 +58,9 @@ case class BagId(override val uuid: UUID) extends ItemId(uuid) {
 
 // FIXME: isDirectory cannot always be known in advance
 case class FileId(bagId: BagId, path: Path, isDirectory: Boolean = false) extends ItemId(bagId.uuid) {
-  private val pathEscaper = UrlEscapers.urlPathSegmentEscaper()
 
   override def toString: String = {
-    s"$bagId/${ path.asScala.map(_.toString).map(pathEscaper.escape).mkString("/") }"
+    s"$bagId/${ path.escapePath }"
   }
 
   override def toBagId: Try[BagId] = Failure(NoBagIdException(this))

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -344,7 +344,7 @@ class StoresServletSpec extends TestSupportFixture
     val itemId = "01000000-0000-0000-0000-000000000001/" + escapePath("unknown-folder/unknown-file")
     get("/store1/bags/01000000-0000-0000-0000-000000000001/unknown-folder/unknown-file") {
       status shouldBe 404
-      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/" + escapePath("unknown-folder/unknown-file") + " not found"
+      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/${escapePath("unknown-folder/unknown-file")} not found"
     }
   }
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -23,6 +23,7 @@ import java.util.{ Base64, UUID }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.model.ZipParameters
+import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
 import org.apache.commons.io.FileUtils
@@ -90,6 +91,10 @@ class StoresServletSpec extends TestSupportFixture
     Files.move(store2.resolve("02/000000000000000000000000000001"), store2.resolve("02/000000000000000000000000000004"))
     Files.move(store2.resolve("02/000000000000000000000000000002"), store2.resolve("02/000000000000000000000000000005"))
     Files.move(store2.resolve("02/000000000000000000000000000003"), store2.resolve("02/000000000000000000000000000006"))
+  }
+
+  private def escapePath(path: String): String = {
+    Paths.get(path).escapePath
   }
 
   private def setBag1Hidden(): Unit = {
@@ -198,18 +203,18 @@ class StoresServletSpec extends TestSupportFixture
     get("/store1/bags/01000000-0000-0000-0000-000000000001", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 200
       body.lines.toList should contain only(
-        "01000000-0000-0000-0000-000000000001/data/x",
-        "01000000-0000-0000-0000-000000000001/data/y",
-        "01000000-0000-0000-0000-000000000001/data/z",
-        "01000000-0000-0000-0000-000000000001/data/sub/u",
-        "01000000-0000-0000-0000-000000000001/data/sub/v",
-        "01000000-0000-0000-0000-000000000001/data/sub/w",
-        "01000000-0000-0000-0000-000000000001/metadata/dataset.xml",
-        "01000000-0000-0000-0000-000000000001/metadata/files.xml",
-        "01000000-0000-0000-0000-000000000001/bagit.txt",
-        "01000000-0000-0000-0000-000000000001/bag-info.txt",
-        "01000000-0000-0000-0000-000000000001/manifest-sha1.txt",
-        "01000000-0000-0000-0000-000000000001/tagmanifest-sha1.txt"
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/x"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/y"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/z"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/u"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/v"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/w"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("metadata/dataset.xml"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("metadata/files.xml"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("bagit.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("bag-info.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("manifest-sha1.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("tagmanifest-sha1.txt")
       )
     }
   }
@@ -247,18 +252,18 @@ class StoresServletSpec extends TestSupportFixture
     get("/store1/bags/01000000-0000-0000-0000-000000000001", params = Map.empty, headers = Map("Accept" -> "text/plain")) {
       status shouldBe 200
       body.lines.toList should contain only(
-        "01000000-0000-0000-0000-000000000001/data/x",
-        "01000000-0000-0000-0000-000000000001/data/y",
-        "01000000-0000-0000-0000-000000000001/data/z",
-        "01000000-0000-0000-0000-000000000001/data/sub/u",
-        "01000000-0000-0000-0000-000000000001/data/sub/v",
-        "01000000-0000-0000-0000-000000000001/data/sub/w",
-        "01000000-0000-0000-0000-000000000001/metadata/dataset.xml",
-        "01000000-0000-0000-0000-000000000001/metadata/files.xml",
-        "01000000-0000-0000-0000-000000000001/bagit.txt",
-        "01000000-0000-0000-0000-000000000001/bag-info.txt",
-        "01000000-0000-0000-0000-000000000001/manifest-sha1.txt",
-        "01000000-0000-0000-0000-000000000001/tagmanifest-sha1.txt"
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/x"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/y"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/z"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/u"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/v"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("data/sub/w"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("metadata/dataset.xml"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("metadata/files.xml"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("bagit.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("bag-info.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("manifest-sha1.txt"),
+        "01000000-0000-0000-0000-000000000001/" + escapePath("tagmanifest-sha1.txt")
       )
     }
   }
@@ -336,9 +341,10 @@ class StoresServletSpec extends TestSupportFixture
   }
 
   it should "fail when the file is not found" in {
+    val itemId = "01000000-0000-0000-0000-000000000001/" + escapePath("unknown-folder/unknown-file")
     get("/store1/bags/01000000-0000-0000-0000-000000000001/unknown-folder/unknown-file") {
       status shouldBe 404
-      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/unknown-folder/unknown-file not found"
+      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/" + escapePath("unknown-folder/unknown-file") + " not found"
     }
   }
 


### PR DESCRIPTION
#### When applied it
* replaces calls to `Guava UrlEscapers` methods with calls to `dans-scala-lib `encoding methods
  (which in turn make use of `Guava PercentEscaper`)


#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-auth-info                 | [DANS-KNAW/easy-auth-info/pull/23] | ..
easy-download                | [DANS-KNAW/easy-download/pull/33] | ..
easy-ingest-flow             | [DANS-KNAW/easy-ingest-flow/pull/109] | ..
easy-solr4files-index      | [DANS-KNAW/easy-solr4files-index/pull/39] | ..
easy-validate-dans-bag | [DANS-KNAW/easy-validate-dans-bag/pull/57] | ..