### PR TITLE
EASY-2136: Content-Length header in easy-bag-store response

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -173,6 +173,19 @@ trait BagStoreComponent {
       }
     }
 
+    def getSize(itemId: ItemId): Try[Long] = {
+      trace(itemId)
+      val bagId = BagId(itemId.uuid)
+
+      fileSystem.checkBagExists(bagId).flatMap { _ =>
+        for {
+          bagDir <- fileSystem.toLocation(bagId)
+          itemPath <- itemId.toFileId.map(f => bagDir.resolve(f.path))
+          size = Files.size(itemPath)
+        } yield size
+      }
+    }
+
     private def fileIsFound(entriesCount: Int, itemId: ItemId): Try[Unit] = Try {
       if (entriesCount == 0)
         throw NoSuchItemException(itemId)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -68,7 +68,8 @@ trait BagStoresComponent {
 
     def getSize(itemId: ItemId, fromStore: Option[BaseDir] = None): Try[Long] = {
       fromStore
-        .map(BagStore(_).getSize(itemId)).getOrElse(Failure(NoSuchBagException(BagId(itemId.uuid))))
+        .map(BagStore(_).getSize(itemId))
+        .getOrElse(Failure(NoSuchBagException(BagId(itemId.uuid))))
     }
 
     def enumBags(includeActive: Boolean = true, includeInactive: Boolean = false, fromStore: Option[BaseDir] = None): Try[Seq[BagId]] = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -66,6 +66,11 @@ trait BagStoresComponent {
         }
     }
 
+    def getSize(itemId: ItemId, fromStore: Option[BaseDir] = None): Try[Long] = {
+      fromStore
+        .map(BagStore(_).getSize(itemId)).getOrElse(Failure(NoSuchBagException(BagId(itemId.uuid))))
+    }
+
     def enumBags(includeActive: Boolean = true, includeInactive: Boolean = false, fromStore: Option[BaseDir] = None): Try[Seq[BagId]] = {
       fromStore
         .map(BagStore(_).enumBags(includeActive, includeInactive))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -211,11 +211,9 @@ trait StoresServletComponent {
   }
 
   private def getHeaders(itemId: ItemId, baseDir: BaseDir): Try[Map[String, String]] = Try {
-    val size = bagStores.getSize(itemId, Some(baseDir))
-    if (size.isSuccess)
-      Map("File-Size" -> size.get.toString)
-    else
-      Map()
+    bagStores.getSize(itemId, Some(baseDir))
+      .map(s => Map("File-Size" -> s.toString))
+      .getOrElse(Map.empty)
   }
 
   private def validateContentTypeHeader(requestContentType: Option[String], uuid: UUID): Try[UUID] = {


### PR DESCRIPTION
Fixes EASY-2136

To do:
* [ ] Unit tests
* [ ] Document new design for filesizes api in api.yml
* [ ] Implement filesizes API

#### When applied it will...
* send response `headers` with a `File-Size` header when url complies to `/:bagstore/bags/:uuid/*` and http method is `HEAD`.
* Normally speaking,  the file would be written to the output stream but only the headers would be sent in the response, giving the `Content-Length` (the size of the the file) in the headers.  But when file size exceeds certain limit `chunked transfer encoding` is used and then there is no `Content-Length` available. Also when writing the file size to a different header (e.g. `File-Size`), it will be deleted from the headers that eventually are sent in the response, when chunked transfer encoding is used.
* In this solution, when url complies to `/:bagstore/bags/:uuid/*` and http method is `HEAD`, the file is not first written to the output stream, but the file size is queried and that is sent in the `response` headers.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-solr4files-index                      | [PR#42](https://github.com/DANS-KNAW/easy-solr4files-index/pull/42) 
