### PR TITLE
EASY-2136: File download with content length

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -120,34 +120,6 @@ paths:
         410:
           description: The bag containing the item is `INACTIVE`.
 
-  /bags/filesizes/{uuid}/{path}:
-    get:
-      summary: Returns the file size of a file, from a bag in any of the bag stores managed by this service.
-      description: |
-        A file is a regular file in a bag.
-
-         * The file is specified by the path of the requested file within the bag.
-         * The path may consist of more than one component.
-         * Not found response is given if the file is not a regular file
-
-        ```
-        example path:
-           for file:      /path/to/file
-           in bag:        40594b6d-8378-4260-b96b-13b57beadf7c/
-           {uuid}/{path}: 40594b6d-8378-4260-b96b-13b57beadf7c/path/to/file
-        ```
-
-      parameters:
-        - $ref: '#/components/parameters/Uuid'
-        - $ref: '#/components/parameters/FilePath'
-      responses:
-        200:
-          $ref: '#/components/responses/GetItemFromBagOk'
-        400:
-          description: Bad request.
-        404:
-          description: The item could not be found.
-
   /stores:
     get:
       operationId: getStores
@@ -296,36 +268,6 @@ paths:
           description: The item could not be found.
         409:
           description: The bag containing the item is `INACTIVE`.
-
-  /stores/{store}/bags/filesizes/{uuid}/{path}:
-    get:
-      summary: Returns the file size of a file in the specified bag store.
-      description: |
-        A file is a regular file in a bag.
-
-         * The file is specified by the path of the requested file within the bag.
-         * The path may consist of more than one component.
-         * Not found response is given if the file is not a regular file
-
-        ```
-        example path:
-           for file:      /path/to/file
-           in bag:        40594b6d-8378-4260-b96b-13b57beadf7c/
-           {uuid}/{path}: 40594b6d-8378-4260-b96b-13b57beadf7c/path/to/file
-        ```
-
-      parameters:
-        - $ref: '#/components/parameters/Store'
-        - $ref: '#/components/parameters/Uuid'
-        - $ref: '#/components/parameters/FilePath'
-      responses:
-        200:
-          $ref: '#/components/responses/GetItemFromBagOk'
-        400:
-          description: Bad request.
-        404:
-          description: The item could not be found.
-
 
 components:
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -167,8 +167,10 @@ trait BagStoreComponent {
         allEntries = () => (dirSpecs ++ fileSpecs).sortBy(_.entryPath) // only concat and sort if necessary, hence as a function here
         _ <- fileIsFound(allEntriesCount, itemId)
         _ <- validateThatBagDirIsNotHidden(bagDir, itemId, forceInactive) // if the bag is hidden, also don't return a specific item from the bag
-        maybePath <- archiveStreamType.map(copyToArchiveStream(outputStream)(allEntries)(_).map(_ => Option.empty))
-          .getOrElse(findFile(itemId, fileIds, allEntriesCount).map(Option(_)))
+        maybePath <- archiveStreamType match {
+          case Some(value) => copyToArchiveStream(outputStream)(allEntries)(value).map(_ => Option.empty)
+          case None => findFile(itemId, fileIds, allEntriesCount).map(Option(_))
+        }
       } yield maybePath
     }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -52,12 +52,12 @@ trait BagStoresComponent {
         }
     }
 
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
+    def getFile(itemId: ItemId, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Path] = {
       fromStore
-        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
+        .map(BagStore(_).getFile(itemId, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
+            .map(BagStore(_).getFile(itemId, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true
@@ -66,12 +66,12 @@ trait BagStoresComponent {
         }
     }
 
-    def getSize(itemId: ItemId, fromStore: Option[BaseDir] = None): Try[Long] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
       fromStore
-        .map(BagStore(_).getSize(itemId))
+        .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
         .getOrElse {
           storeShortnames.values.toStream
-            .map(BagStore(_).getSize(itemId))
+            .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
             .find {
               case Failure(_: NoSuchBagException) => false
               case _ => true

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -52,21 +52,7 @@ trait BagStoresComponent {
         }
     }
 
-    def getFile(itemId: ItemId, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Path] = {
-      fromStore
-        .map(BagStore(_).getFile(itemId, forceInactive))
-        .getOrElse {
-          storeShortnames.values.toStream
-            .map(BagStore(_).getFile(itemId, forceInactive))
-            .find {
-              case Failure(_: NoSuchBagException) => false
-              case _ => true
-            }
-            .getOrElse(Failure(NoSuchBagException(BagId(itemId.uuid))))
-        }
-    }
-
-    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Unit] = {
+    def copyToStream(itemId: ItemId, archiveStreamType: Option[ArchiveStreamType], outputStream: => OutputStream, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[Option[Path]] = {
       fromStore
         .map(BagStore(_).copyToStream(itemId, archiveStreamType, outputStream, forceInactive))
         .getOrElse {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/BagsServletComponent.scala
@@ -15,6 +15,8 @@
  */
 package nl.knaw.dans.easy.bagstore.server
 
+import java.io.File
+
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.BagStoresComponent
 import nl.knaw.dans.lib.error._
@@ -75,8 +77,6 @@ trait BagsServletComponent {
         }
     }
 
-    // please note that the order in which '/:uuid/*' and '/filesizes/:uuid/*' appear is important!
-    // see http://scalatra.org/guides/2.6/http/routes.html#route-order
     get("/:uuid/*") {
       val uuidStr = params("uuid")
       multiParams("splat") match {
@@ -87,9 +87,16 @@ trait BagsServletComponent {
             }
             .flatMap(itemId => {
               debug(s"Retrieving item $itemId")
-              bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType), response.outputStream)
+              request.header("Accept").flatMap(acceptToArchiveStreamType)
+                .map(ast => bagStores.copyToStream(itemId, Some(ast), response.outputStream))
+                .getOrElse(bagStores.getFile(itemId).map(_.toFile))
             })
-            .map(_ => Ok())
+            .map {
+              case file: File =>
+                response.setContentLengthLong(file.length())
+                Ok(file)
+              case _ => Ok()
+            }
             .getOrRecover {
               case e: IllegalArgumentException => BadRequest(e.getMessage)
               case e: NoRegularFileException => BadRequest(e.getMessage)
@@ -97,33 +104,6 @@ trait BagsServletComponent {
               case e: NoSuchFileItemException => NotFound(e.getMessage)
               case e: NoSuchItemException => NotFound(e.getMessage)
               case e: InactiveException => Gone(e.getMessage)
-              case NonFatal(e) =>
-                logger.error("Error retrieving bag", e)
-                InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-            }
-        case p =>
-          logger.error(s"Unexpected path: $p")
-          InternalServerError("Unexpected path")
-      }
-    }
-
-    // please note that the order in which '/:uuid/*' and '/filesizes/:uuid/*' appear is important!
-    // see http://scalatra.org/guides/2.6/http/routes.html#route-order
-    get("/filesizes/:uuid/*") {
-      val uuidStr = params("uuid")
-      multiParams("splat") match {
-        case Seq(path) =>
-          ItemId.fromString(s"""$uuidStr/${ path }""")
-            .recoverWith {
-              case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
-            }
-            .flatMap(itemId => bagStores.getSize(itemId))
-            .map(size => Ok(body = size))
-            .getOrRecover {
-              case e: IllegalArgumentException => BadRequest(e.getMessage)
-              case e: NoSuchBagException => NotFound(e.getMessage)
-              case e: NoSuchItemException => NotFound(e.getMessage)
-              case e: NoRegularFileException => NotFound(e.getMessage)
               case NonFatal(e) =>
                 logger.error("Error retrieving bag", e)
                 InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -15,6 +15,7 @@
  */
 package nl.knaw.dans.easy.bagstore.server
 
+import java.io.File
 import java.net.URI
 import java.util.UUID
 
@@ -114,8 +115,6 @@ trait StoresServletComponent {
         .getOrElse(NotFound(s"No such bag-store: $bagstore"))
     }
 
-    // please note that the order in which '/:bagstore/bags/:uuid/*' and '/:bagstore/bags/filesizes/:uuid/*' appear is important!
-    // see http://scalatra.org/guides/2.6/http/routes.html#route-order
     get("/:bagstore/bags/:uuid/*") {
       val bagstore = params("bagstore")
       val uuidStr = params("uuid")
@@ -128,9 +127,16 @@ trait StoresServletComponent {
               }
               .flatMap(itemId => {
                 debug(s"Retrieving item $itemId")
-                bagStores.copyToStream(itemId, request.header("Accept").flatMap(acceptToArchiveStreamType), response.outputStream, Some(baseDir))
+                request.header("Accept").flatMap(acceptToArchiveStreamType)
+                  .map(ast => bagStores.copyToStream(itemId, Some(ast), response.outputStream, Some(baseDir)))
+                  .getOrElse(bagStores.getFile(itemId, Some(baseDir)).map(_.toFile))
               })
-              .map(_ => Ok())
+              .map {
+                case file: File =>
+                  response.setContentLengthLong(file.length())
+                  Ok(file)
+                case _ => Ok()
+              }
               .getOrRecover {
                 case e: IllegalArgumentException => BadRequest(e.getMessage)
                 case e: NoRegularFileException => BadRequest(e.getMessage)
@@ -138,36 +144,6 @@ trait StoresServletComponent {
                 case e: NoSuchBagException => NotFound(e.getMessage)
                 case e: NoSuchFileItemException => NotFound(e.getMessage)
                 case e: InactiveException => Gone(e.getMessage)
-                case NonFatal(e) =>
-                  logger.error("Error retrieving bag", e)
-                  InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")
-              })
-            .getOrElse(NotFound(s"No such bag-store: $bagstore"))
-        case p =>
-          logger.error(s"Unexpected path: $p")
-          InternalServerError("Unexpected path")
-      }
-    }
-
-    // please note that the order in which '/:bagstore/bags/:uuid/*' and '/:bagstore/bags/filesizes/:uuid/*' appear is important!
-    // see http://scalatra.org/guides/2.6/http/routes.html#route-order
-    get("/:bagstore/bags/filesizes/:uuid/*") {
-      val bagstore = params("bagstore")
-      val uuidStr = params("uuid")
-      multiParams("splat") match {
-        case Seq(path) =>
-          bagStores.getBaseDirByShortname(bagstore)
-            .map(baseDir => ItemId.fromString(s"""$uuidStr/${ path }""")
-              .recoverWith {
-                case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"Invalid UUID string: $uuidStr"))
-              }
-              .flatMap(itemId => bagStores.getSize(itemId, Some(baseDir)))
-              .map(size => Ok(body = size))
-              .getOrRecover {
-                case e: IllegalArgumentException => BadRequest(e.getMessage)
-                case e: NoRegularFileException => NotFound(e.getMessage)
-                case e: NoSuchItemException => NotFound(e.getMessage)
-                case e: NoSuchBagException => NotFound(e.getMessage)
                 case NonFatal(e) =>
                   logger.error("Error retrieving bag", e)
                   InternalServerError(s"[${ new DateTime() }] Unexpected type of failure. Please consult the logs")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -23,9 +23,9 @@ import java.util.{ Base64, UUID }
 
 import net.lingala.zip4j.core.ZipFile
 import net.lingala.zip4j.model.ZipParameters
-import nl.knaw.dans.lib.encode.PathEncoding
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
+import nl.knaw.dans.lib.encode.PathEncoding
 import org.apache.commons.io.FileUtils
 import org.scalatra.test.EmbeddedJettyContainer
 import org.scalatra.test.scalatest.ScalatraSuite
@@ -297,8 +297,10 @@ class StoresServletSpec extends TestSupportFixture
     get("/store1/bags/01000000-0000-0000-0000-000000000001/data/y") {
       status shouldBe 200
 
-      Source.fromInputStream(response.inputStream).mkString shouldBe
-        Source.fromFile(store1.resolve("01/000000000000000000000000000001/bag-revision-1/data/y").toFile).mkString
+      val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/data/y")
+
+      header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
+      Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
     }
   }
 
@@ -306,8 +308,10 @@ class StoresServletSpec extends TestSupportFixture
     get("/store1/bags/01000000-0000-0000-0000-000000000001/metadata/files.xml") {
       status shouldBe 200
 
-      Source.fromInputStream(response.inputStream).mkString shouldBe
-        Source.fromFile(store1.resolve("01/000000000000000000000000000001/bag-revision-1/metadata/files.xml").toFile).mkString
+      val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/metadata/files.xml")
+
+      header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
+      Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
     }
   }
 
@@ -341,10 +345,9 @@ class StoresServletSpec extends TestSupportFixture
   }
 
   it should "fail when the file is not found" in {
-    val itemId = "01000000-0000-0000-0000-000000000001/" + escapePath("unknown-folder/unknown-file")
     get("/store1/bags/01000000-0000-0000-0000-000000000001/unknown-folder/unknown-file") {
       status shouldBe 404
-      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/${escapePath("unknown-folder/unknown-file")} not found"
+      body shouldBe s"Item 01000000-0000-0000-0000-000000000001/${ escapePath("unknown-folder/unknown-file") } not found"
     }
   }
 


### PR DESCRIPTION
Some more fun with EASY-2136

#### When applied it will...
* undo the changes regarding the `filesizes` routes in the `bags` and `store` servlets
* return the file from the route declaration if you're downloading a single file; Scalatra will properly write this to the `response.outputStream` when it is a `java.io.File` according to [Stackoverflow](https://stackoverflow.com/a/5778891/2389405). By this approach we can overcome the 'chunked' download that doesn't accept a `Content-Length` header and set this header ourselves. The trick seems to be to first set the `Content-Length` header and then start writing to the outputstream...
* not yet return a `Content-Length` header when downloading a `*.zip` or `*.tar` file; I don't know yet how to calculate the number of bytes to be written on an `ArchiveStream` before it starts to write something. Sure, I could write the `ArchiveStream` to file, but I don't really want to use extra space for this action.
* just remove the `filesizes` description from the `api.yml` file. I don't know if we should document this `Content-Length` header on 'singular files'.

#### How should this be manually tested?
* Create a deposit with both a large and a small file
* Deposit it using `easy-sword2`
* Make sure it is properly archived in the vault and accessible through `easy-bag-store`
* The following commands should yield a `Content-Length` header:
  ```
  curl -I -X HEAD http://localhost:20110/stores/easy/bags/c0654dc6-b376-4d0a-a6ee-0bbeba1bbbcb/data/movie/Messiah.mp4
  HTTP/1.1 200 OK
  Date: Sat, 20 Jul 2019 15:22:48 GMT
  Content-Type: application/octet-stream;charset=utf-8
  Content-Length: 551067042
  Server: Jetty(9.4.14.v20181114)

  curl -I -X HEAD http://localhost:20110/bags/c0654dc6-b376-4d0a-a6ee-0bbeba1bbbcb/data/movie/Messiah.mp4
  HTTP/1.1 200 OK
  Date: Sat, 20 Jul 2019 17:12:14 GMT
  Content-Type: application/octet-stream;charset=utf-8
  Content-Length: 551067042
  Server: Jetty(9.4.14.v20181114)
  ```
* The following commands should still yield a 'chunked' `Transfer-Encoding` header:
  ```
  curl -I -X HEAD -H "accept: application/zip" http://localhost:20110/stores/easy/bags/c0654dc6-b376-4d0a-a6ee-0bbeba1bbbcb/data
  HTTP/1.1 200 OK
  Date: Sat, 20 Jul 2019 17:12:31 GMT
  Transfer-Encoding: chunked
  Server: Jetty(9.4.14.v20181114)

  curl -I -X HEAD -H "accept: application/zip" http://localhost:20110/bags/c0654dc6-b376-4d0a-a6ee-0bbeba1bbbcb/data
  HTTP/1.1 200 OK
  Date: Sat, 20 Jul 2019 17:12:52 GMT
  Transfer-Encoding: chunked
  Server: Jetty(9.4.14.v20181114)
  ```

@DANS-KNAW/easy for review
@janvanmansum @vesaakerman if this really works, we can also revert the work on `easy-solr4files-index` in https://github.com/DANS-KNAW/easy-solr4files-index/pull/43. Could you guys please test that this PR works correctly and that I'm not fooling myself?

**TODO**
* [x] adjust the call in `easy-solr4files-index` accordingly (_done: https://github.com/DANS-KNAW/easy-solr4files-index/pull/47_)