### PR TITLE
EASY-2396. Upgrade commons-compress.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>


### PR DESCRIPTION
Older version contain a security issue (https://nvd.nist.gov/vuln/detail/CVE-2019-12402)

Fixes EASY-2396

#### When applied it will...
* Upgrade the parent pom, so that the newer version of commons-compress is inherited.

#### Where should the reviewer @DANS-KNAW/easy start?

