### PR TITLE
EASY-2332: validation of UUIDs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/ItemId.scala
@@ -33,18 +33,10 @@ abstract class ItemId(val uuid: UUID) {
 object ItemId {
   def fromString(s: String): Try[ItemId] = Try {
     s.split("/", 2) match {
-      case Array(uuidStr) => BagId(UUID.fromString(validateUuidLength(uuidStr)))
+      case Array(uuidStr) => BagId(getUUID(uuidStr))
       case Array(uuidStr, path) =>
-        FileId(UUID.fromString(validateUuidLength(uuidStr)), Paths.get(URLDecoder.decode(path, "UTF-8")))
+        FileId(getUUID(uuidStr), Paths.get(URLDecoder.decode(path, "UTF-8")))
     }
-  }
-
-  private def validateUuidLength(uuidAsString: String): String = {
-    val uuid = uuidAsString.trim
-    if (uuid.length != 36) {
-      throw new IllegalArgumentException(s"A UUID should contain exactly 36 characters, this UUID has ${ uuid.length } characters")
-    }
-    uuid
   }
 }
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -18,9 +18,10 @@ package nl.knaw.dans.easy.bagstore.command
 import java.nio.file.{ Path, Paths }
 import java.util.UUID
 
+import nl.knaw.dans.lib.string._
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
 import nl.knaw.dans.easy.bagstore.{ ArchiveStreamType, ConfigurationComponent }
-import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter }
+import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter, stringConverter }
 
 trait CommandLineOptionsComponent {
   this: ConfigurationComponent =>
@@ -63,7 +64,7 @@ trait CommandLineOptionsComponent {
          |""".stripMargin)
 
     private implicit val fileConverter: ValueConverter[Path] = singleArgConverter[Path](s => Paths.get(resolveTildeToHomeDir(s)))
-    private implicit val uuidParser: ValueConverter[UUID] = singleArgConverter(UUID.fromString)
+    private implicit val uuidParser: ValueConverter[UUID] = stringConverter.flatMap(_.toUUID.fold(e => Left(e.getMessage), uuid => Right(Option(uuid))))
     private implicit val archiveStreamTypeParser: ValueConverter[ArchiveStreamType.Value] = singleArgConverter {
       case "zip" => ArchiveStreamType.ZIP
       case "tar" => ArchiveStreamType.TAR

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -247,7 +247,7 @@ trait BagStoreComponent {
     private def pruneWithReferenceBags(bagDir: Path)(refbags: Path): Try[Unit] = {
       trace(bagDir, refbags)
       for {
-        refs <- Try { Files.readAllLines(refbags).asScala.map(UUID.fromString _ andThen BagId) }
+        refs <- Try { Files.readAllLines(refbags).asScala.map(getUUID _ andThen BagId) }
         _ <- bagProcessing.prune(bagDir, refs)
         _ <- Try { Files.delete(refbags) }
       } yield ()

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -64,8 +64,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
 
         assertUuidPartitionedCorrectly(p.subpath(0, uuidPartCount))
         val uuidStr = formatUuidStrCanonically((0 until uuidPartCount).map(p.getName).mkString)
-        assertUuidValid(uuidStr)
-        val bagId = BagId(UUID.fromString(uuidStr))
+        val bagId = BagId(getUUID(uuidStr))
         if (filePathIndex < nameCount) FileId(bagId, p.subpath(filePathIndex, p.getNameCount))
         else bagId
       }
@@ -77,10 +76,6 @@ trait FileSystemComponent extends DebugEnhancedLogging {
 
     private def formatUuidStrCanonically(s: String): String = {
       List(s.slice(0, 8), s.slice(8, 12), s.slice(12, 16), s.slice(16, 20), s.slice(20, 32)).mkString("-")
-    }
-
-    private def assertUuidValid(uuid: String): Unit = {
-      assert(Try(UUID.fromString(uuid)).map(_ => true).getOrElse(false), s"UUID ($uuid) is not valid")
     }
 
     /**
@@ -120,8 +115,7 @@ trait FileSystemComponent extends DebugEnhancedLogging {
           Failure(IncompleteItemUriException("base-uri by itself is not an item-uri"))
         else {
           val uuidStr = formatUuidStrCanonically(itemIdPath.getName(0).toString.filterNot(_ == '-'))
-          assertUuidValid(uuidStr)
-          val bagId = BagId(UUID.fromString(uuidStr))
+          val bagId = BagId(getUUID(uuidStr))
           if (itemIdPath.getNameCount > 1)
             Try(FileId(bagId, itemIdPath.subpath(1, itemIdPath.getNameCount)))
           else if (uri.toString.endsWith("/"))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -115,13 +115,17 @@ trait FileSystemComponent extends DebugEnhancedLogging {
           Failure(IncompleteItemUriException("base-uri by itself is not an item-uri"))
         else {
           val uuidStr = formatUuidStrCanonically(itemIdPath.getName(0).toString.filterNot(_ == '-'))
-          val bagId = BagId(getUUID(uuidStr))
-          if (itemIdPath.getNameCount > 1)
-            Try(FileId(bagId, itemIdPath.subpath(1, itemIdPath.getNameCount)))
-          else if (uri.toString.endsWith("/"))
-            Try(FileId(bagId, Paths.get("")))
-          else
-            Try(bagId)
+          uuidStr.toUUID.toTry match {
+            case Success(uuid) =>
+              val bagId = BagId(uuid)
+              if (itemIdPath.getNameCount > 1)
+                Try(FileId(bagId, itemIdPath.subpath(1, itemIdPath.getNameCount)))
+              else if (uri.toString.endsWith("/"))
+                     Try(FileId(bagId, Paths.get("")))
+              else
+                Try(bagId)
+            case Failure(e) => Failure(new IllegalArgumentException(e.getMessage))
+          }
         }
       }
       else Failure(NoItemUriException(uri, localBaseUri))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -144,7 +144,7 @@ package object bagstore {
   def getUUID(uuidStr: String): UUID = {
     uuidStr.toUUID.toTry match {
       case Success(uuid) => uuid
-      case Failure(error) => throw new Exception(error)
+      case Failure(e) => throw new IllegalArgumentException(e.getMessage)
     }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -140,7 +140,7 @@ package object bagstore {
     list.toSet
   }
 
-  @throws[IllegalArgumentException]("String '$uuidStr' is not a UUID")
+  @throws[IllegalArgumentException]("when the input String does not represent a valid UUID")
   def getUUID(uuidStr: String): UUID = {
     uuidStr.toUUID.toTry
       .getOrRecover(e => throw new IllegalArgumentException(e.getMessage, e))

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -17,6 +17,9 @@ package nl.knaw.dans.easy
 
 import java.net.URI
 import java.nio.file.{ Files, Path }
+import java.util.UUID
+
+import nl.knaw.dans.lib.string._
 
 import org.apache.commons.io.FileUtils
 import resource._
@@ -136,5 +139,12 @@ package object bagstore {
       list += path.subpath(0, i)
     }
     list.toSet
+  }
+
+  def getUUID(uuidStr: String): UUID = {
+    uuidStr.toUUID.toTry match {
+      case Success(uuid) => uuid
+      case Failure(error) => throw new Exception(error)
+    }
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -20,14 +20,13 @@ import java.nio.file.{ Files, Path }
 import java.util.UUID
 
 import nl.knaw.dans.lib.string._
-
 import org.apache.commons.io.FileUtils
 import resource._
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Failure, Success }
 
 package object bagstore {
   case class NoItemUriException(uri: URI, baseUri: URI) extends Exception(s"Base of URI $uri is not an item-uri: does not match base-uri; base-uri is $baseUri")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -19,6 +19,7 @@ import java.net.URI
 import java.nio.file.{ Files, Path }
 import java.util.UUID
 
+import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.string._
 import org.apache.commons.io.FileUtils
 import resource._
@@ -26,7 +27,6 @@ import resource._
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
-import scala.util.{ Failure, Success }
 
 package object bagstore {
   case class NoItemUriException(uri: URI, baseUri: URI) extends Exception(s"Base of URI $uri is not an item-uri: does not match base-uri; base-uri is $baseUri")
@@ -140,10 +140,9 @@ package object bagstore {
     list.toSet
   }
 
+  @throws[IllegalArgumentException]("String '$uuidStr' is not a UUID")
   def getUUID(uuidStr: String): UUID = {
-    uuidStr.toUUID.toTry match {
-      case Success(uuid) => uuid
-      case Failure(e) => throw new IllegalArgumentException(e.getMessage)
-    }
+    uuidStr.toUUID.toTry
+      .getOrRecover(e => throw new IllegalArgumentException(e.getMessage, e))
   }
 }

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -164,9 +164,6 @@ trait StoresServletComponent {
       bagStores.getBaseDirByShortname(bagStore)
         .map(base => {
           uuidStr.toUUID.toTry
-            .recoverWith {
-              case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
-            }
             .flatMap(validateContentTypeHeader(requestContentType, _))
             .flatMap(bagStores.putBag(request.getInputStream, base, _))
             .map(bagId => Created(headers = Map(
@@ -176,6 +173,7 @@ trait StoresServletComponent {
               case e: CompositeException if e.throwables.exists(_.isInstanceOf[IncorrectNumberOfFilesInBagZipRootException]) => BadRequest(e.getMessage())
               case e: UnsupportedMediaTypeException => UnsupportedMediaType(e.getMessage)
               case e: IllegalArgumentException => BadRequest(e.getMessage)
+              case e: UUIDError => BadRequest(e.getMessage)
               case e: BagIdAlreadyAssignedException => BadRequest(e.getMessage)
               case e: NoBagException => BadRequest(e.getMessage)
               case e: InvalidBagException => BadRequest(e.getMessage)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/server/StoresServletComponent.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.{ BagStoresComponent, FileSystemComponent }
 import nl.knaw.dans.lib.error._
+import nl.knaw.dans.lib.string._
 import nl.knaw.dans.lib.logging.servlet._
 import nl.knaw.dans.lib.logging.servlet.masked.MaskedAuthorizationHeader
 import org.joda.time.DateTime
@@ -162,7 +163,7 @@ trait StoresServletComponent {
       val requestContentType = Option(request.getHeader("Content-Type"))
       bagStores.getBaseDirByShortname(bagStore)
         .map(base => {
-          Try { UUID.fromString(uuidStr) }
+          uuidStr.toUUID.toTry
             .recoverWith {
               case _: IllegalArgumentException => Failure(new IllegalArgumentException(s"invalid UUID string: $uuidStr"))
             }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/ItemIdSpec.scala
@@ -79,34 +79,32 @@ class ItemIdSpec extends TestSupportFixture {
 
   it should "trigger an IllegalArgumentException when presented a too long UUID at the end should" in {
     val tooLongUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abcdef1278713487134"
-    expectValidationToFailOnUuidLength(tooLongUuidAtEnd)
+    expectUuidValidationToFail(tooLongUuidAtEnd)
   }
 
   it should "trigger an IllegalArgumentException when presented a too long UUID at the start should" in {
     val tooLongUuidAtStart = "12787134871341234abcd-12AB-12ab-12AB-123456abcdef"
-    expectValidationToFailOnUuidLength(tooLongUuidAtStart)
+    expectUuidValidationToFail(tooLongUuidAtStart)
   }
 
   it should "trigger an IllegalArgumentException when presented a nonsense UUID with the right amount of characters" in {
     val nonsenseUuid = "a badly formatted uuid with 36 chars"
-    fromString(nonsenseUuid) shouldBe a[Failure[_]]
+    expectUuidValidationToFail(nonsenseUuid)
   }
 
   it should "trigger an IllegalArgumentException when presented an UUID with special characters" in {
     val uuidWithExclamationMark = "1234abcd-12AB-12ab-12AB-123456abcde!"
-    fromString(uuidWithExclamationMark) should matchPattern {
-      case Failure(e: NumberFormatException) if e.getMessage.equals("""For input string: "123456abcde!"""") =>
-    }
+    expectUuidValidationToFail(uuidWithExclamationMark)
   }
 
   it should "trigger an IllegalArgumentException when presented a too short UUID at start" in {
     val tooShortUuidAtStart = "bcd-12AB-12ab-12AB-123456abcdef"
-    expectValidationToFailOnUuidLength(tooShortUuidAtStart)
+    expectUuidValidationToFail(tooShortUuidAtStart)
   }
 
   it should "trigger an IllegalArgumentException when presented a too short UUID at the end" in {
     val tooShortUuidAtEnd = "1234abcd-12AB-12ab-12AB-123456abc"
-    expectValidationToFailOnUuidLength(tooShortUuidAtEnd)
+    expectUuidValidationToFail(tooShortUuidAtEnd)
   }
 
   "BagId.toString" should "print UUID" in {
@@ -161,9 +159,9 @@ class ItemIdSpec extends TestSupportFixture {
     }
   }
 
-  private def expectValidationToFailOnUuidLength(nonsenseUuid: String) = {
-    fromString(nonsenseUuid) should matchPattern {
-      case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"A UUID should contain exactly 36 characters, this UUID has ${ nonsenseUuid.length } characters") =>
+  private def expectUuidValidationToFail(uuid: String) = {
+    fromString(uuid) should matchPattern {
+      case Failure(e: IllegalArgumentException) if e.getMessage.contains(s"String '$uuid' is not a UUID") =>
     }
   }
 }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/FileSystemSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/FileSystemSpec.scala
@@ -126,6 +126,11 @@ class FileSystemSpec extends TestSupportFixture
     fileSystem.fromUri(uri) should matchPattern { case Failure(NoItemUriException(`uri`, `localBaseUri`)) => }
   }
 
+  it should "return a failure with invalid UUID" in {
+    val uri = new URI(s"$localBaseUri/abc")
+    fileSystem.fromUri(uri) should matchPattern { case Failure(e: IllegalArgumentException) if e.getMessage == "String 'abc----' is not a UUID" => }
+  }
+
   it should "return a bag-id for valid UUID-path after the base-uri" in {
     val uuid = UUID.randomUUID()
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -512,7 +512,7 @@ class StoresServletSpec extends TestSupportFixture
     val uuid = "11111111111111111111111111111111"
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedA), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
-      body shouldBe s"invalid UUID string: $uuid"
+      body shouldBe s"String '$uuid' is not a UUID"
     }
   }
 
@@ -520,7 +520,7 @@ class StoresServletSpec extends TestSupportFixture
     val uuid = "abc-def-ghi-jkl-mno"
     put(s"/store1/bags/$uuid", headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
-      body shouldBe s"invalid UUID string: $uuid"
+      body shouldBe s"String '$uuid' is not a UUID"
     }
   }
 
@@ -556,7 +556,7 @@ class StoresServletSpec extends TestSupportFixture
     val uuid = "11111111-1121-1111-1111-111111111111"
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
-      body shouldBe s"Invalid UUID string: $content"
+      body shouldBe s"String '$content' is not a UUID"
     }
   }
 


### PR DESCRIPTION
Fixes EASY-2332

#### When applied it will
* validate `UUIDs` using `dans.lib.string.toUUID` method

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-archive-bag   | [PR#66](https://github.com/DANS-KNAW/easy-archive-bag/pull/66)     | ..
easy-auth-info   | [PR#36](https://github.com/DANS-KNAW/easy-auth-info/pull/36)     | ..
easy-bag-index  | [PR#50](https://github.com/DANS-KNAW/easy-bag-index/pull/50)     | ..
easy-delete-dataset  | [PR#19](https://github.com/DANS-KNAW/easy-delete-dataset/pull/19)     | ..
easy-deposit-api  | [PR#204](https://github.com/DANS-KNAW/easy-deposit-api/pull/204)     | ..
easy-deposit-properties  | [PR#23](https://github.com/DANS-KNAW/easy-deposit-properties/pull/23)     | ..
easy-ingest-flow  | [PR#137](https://github.com/DANS-KNAW/easy-ingest-flow/pull/137)     | ..
easy-solr4files-index  | [PR#54](https://github.com/DANS-KNAW/easy-solr4files-index/pull/54)     | ..
easy-split-multi-deposit  | [PR#146](https://github.com/DANS-KNAW/easy-split-multi-deposit/pull/146)     | ..
easy-transform-metadata  | [PR#11](https://github.com/DANS-KNAW/easy-transform-metadata/pull/11)     | ..
easy-validate-dans-bag  | [PR#73](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/73)     | ..

