### PR TITLE
EASY-2648: Make easy-bag-store the only user that can execute the easy-bag-store command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
                             <mappings combine.children="append">
                                 <mapping>
                                     <directory>/opt/${dans-provider-name}/${project.artifactId}/bin</directory>
-                                    <filemode>744</filemode>
+                                    <filemode>544</filemode>
                                     <username>easy-bag-store</username>
                                     <groupname>easy-bag-store</groupname>
                                     <sources>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,9 @@
                             <mappings combine.children="append">
                                 <mapping>
                                     <directory>/opt/${dans-provider-name}/${project.artifactId}/bin</directory>
-                                    <filemode>755</filemode>
+                                    <filemode>744</filemode>
+                                    <username>easy-bag-store</username>
+                                    <groupname>easy-bag-store</groupname>
                                     <sources>
                                         <source>
                                             <location>src/main/assembly/dist/bin/${project.artifactId}</location>

--- a/src/main/assembly/dist/cfg/logback.xml
+++ b/src/main/assembly/dist/cfg/logback.xml
@@ -8,9 +8,9 @@
 
     <appender name="FILE"
               class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/easy-bag-store.log</file>
+        <file>/var/opt/dans.knaw.nl/log/easy-bag-store/easy-bag-store-cli.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${user.home}/easy-bag-store.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>/var/opt/dans.knaw.nl/log/easy-bag-store/easy-bag-store-cli.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>


### PR DESCRIPTION
Fixes EASY-2648

#### When applied it will...
* Make sure the `easy-bag-store` executable is owned by `easy-bag-store` and has mode 744.
* Together with https://github.com/DANS-KNAW/easy-dtap/pull/449, this ensures that funcadmin can only execute `easy-bag-store` but not change files owned by `easy-bag-store` directly.

#### Where should the reviewer @DANS-KNAW/easy start?
* The pom

#### How should this be manually tested?
See https://github.com/DANS-KNAW/easy-dtap/pull/449 

#### Related pull requests on github
https://github.com/DANS-KNAW/easy-dtap/pull/449