### PR TITLE
EASY-1945: upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>5.1.2</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>nl.knaw.dans.easy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.6</version>
         </dependency>
         <dependency>
             <groupId>gov.loc</groupId>
@@ -79,7 +78,7 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-bag-lib_2.12</artifactId>
-            <version>1.0.0-beta-2</version>
+            <version>1.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -93,12 +92,10 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-scala-lib_2.12</artifactId>
-            <version>1.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -119,7 +116,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.scalatra</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
         <dependency>
             <groupId>nl.knaw.dans.lib</groupId>
             <artifactId>dans-bag-lib_2.12</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingComponent.scala
@@ -17,12 +17,11 @@ package nl.knaw.dans.easy.bagstore.component
 
 import java.io.{ IOException, InputStream }
 import java.net.URI
-import java.nio.charset.StandardCharsets
 import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermission }
 import java.nio.file.{ FileVisitResult, FileVisitor, Files, Path }
 import java.util.{ Set => JSet }
 
-import net.lingala.zip4j.core.ZipFile
+import net.lingala.zip4j.ZipFile
 import net.lingala.zip4j.exception.ZipException
 import net.lingala.zip4j.model.ZipParameters
 import nl.knaw.dans.easy.bagstore._
@@ -159,9 +158,7 @@ trait BagProcessingComponent extends DebugEnhancedLogging {
         Files.createDirectory(extractDir)
         val zip = extractDir.resolve("bag.zip")
         FileUtils.copyInputStreamToFile(is, zip.toFile)
-        new ZipFile(zip.toFile) {
-          setFileNameCharset(StandardCharsets.UTF_8.name)
-        }.extractAll(extractDir.toAbsolutePath.toString)
+        new ZipFile(zip.toFile).extractAll(extractDir.toAbsolutePath.toString)
         Files.delete(zip)
         extractDir
       }.recoverWith {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagProcessingSpec.scala
@@ -93,9 +93,9 @@ class BagProcessingSpec extends BagProcessingFixture
   it should "result in a failure if there are no files in the zip file" in {
     FileUtils.copyDirectory(Paths.get("src/test/resources/bag-store").toFile, store1.toFile)
 
-    bagProcessing.unzipBag(new FileInputStream("src/test/resources/zips/empty.zip")) shouldBe a[Failure[_]]
-    // Actually, stageBagZip should not end in Failure, but it does because lingala chokes on the empty zip
-    // This is the next best thing.
+    inside(bagProcessing.unzipBag(new FileInputStream("src/test/resources/zips/empty.zip"))) {
+      case Success(staging) => staging.getParent shouldBe stagingBaseDir
+    }
   }
 
   it should "result in a failure if there is no base directory in the zip file" in {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -67,7 +67,7 @@ class BagsServletSpec extends TestSupportFixture
   "get" should "enumerate the bags in all bag-stores" in {
     get("/") {
       status shouldBe 200
-      body.lines.toList should contain only(
+      body.linesIterator.toList should contain only(
         "01000000-0000-0000-0000-000000000001",
         "01000000-0000-0000-0000-000000000002",
         "01000000-0000-0000-0000-000000000003",
@@ -83,7 +83,7 @@ class BagsServletSpec extends TestSupportFixture
 
     get("/", "state" -> "inactive") {
       status shouldBe 200
-      body.lines.toList should contain only "01000000-0000-0000-0000-000000000001"
+      body.linesIterator.toList should contain only "01000000-0000-0000-0000-000000000001"
     }
   }
 
@@ -92,7 +92,7 @@ class BagsServletSpec extends TestSupportFixture
 
     get("/") {
       status shouldBe 200
-      body.lines.toList should contain only(
+      body.linesIterator.toList should contain only(
         "01000000-0000-0000-0000-000000000002",
         "01000000-0000-0000-0000-000000000003",
         "02000000-0000-0000-0000-000000000001",
@@ -107,7 +107,7 @@ class BagsServletSpec extends TestSupportFixture
 
     get("/", "state" -> "all") {
       status shouldBe 200
-      body.lines.toList should contain only(
+      body.linesIterator.toList should contain only(
         "01000000-0000-0000-0000-000000000001",
         "01000000-0000-0000-0000-000000000002",
         "01000000-0000-0000-0000-000000000003",
@@ -140,7 +140,7 @@ class BagsServletSpec extends TestSupportFixture
   it should "enumerate the bags in all bag-stores even if an unknown state is given" in {
     get("/", params = Map("state" -> "invalid value"), headers = Map("Accept" -> "text/plain")) {
       status shouldBe 200
-      body.lines.toList should contain only(
+      body.linesIterator.toList should contain only(
         "01000000-0000-0000-0000-000000000001",
         "01000000-0000-0000-0000-000000000002",
         "01000000-0000-0000-0000-000000000003",
@@ -154,7 +154,7 @@ class BagsServletSpec extends TestSupportFixture
   "get uuid" should "enumerate the files of a given bag" in {
     get("/01000000-0000-0000-0000-000000000001", headers = Map("Accept" -> "text/plain")) {
       status shouldBe 200
-      body.lines.toList should contain only(
+      body.linesIterator.toList should contain only(
         "01000000-0000-0000-0000-000000000001/" + escapePath("data/x"),
         "01000000-0000-0000-0000-000000000001/" + escapePath("data/y"),
         "01000000-0000-0000-0000-000000000001/" + escapePath("data/z"),
@@ -260,7 +260,7 @@ class BagsServletSpec extends TestSupportFixture
 
       val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/data/y")
 
-      header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
+      response.header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
       Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
     }
   }
@@ -271,7 +271,7 @@ class BagsServletSpec extends TestSupportFixture
 
       val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/metadata/files.xml")
 
-      header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
+      response.header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
       Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
     }
   }

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -18,6 +18,7 @@ package nl.knaw.dans.easy.bagstore.server
 import java.nio.file.{ Files, Paths }
 import java.util.UUID
 
+import better.files.File
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.component.{ BagProcessingComponent, BagStoreComponent, BagStoresComponent, FileSystemComponent }
 import nl.knaw.dans.lib.encode.PathEncoding
@@ -261,7 +262,7 @@ class BagsServletSpec extends TestSupportFixture
       val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/data/y")
 
       response.header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
-      Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
+      Source.fromInputStream(response.inputStream).mkString shouldBe File(expectedFilePath).contentAsString
     }
   }
 
@@ -272,7 +273,7 @@ class BagsServletSpec extends TestSupportFixture
       val expectedFilePath = store1.resolve("01/000000000000000000000000000001/bag-revision-1/metadata/files.xml")
 
       response.header("Content-Length").toLong shouldBe Files.size(expectedFilePath)
-      Source.fromInputStream(response.inputStream).mkString shouldBe Source.fromFile(expectedFilePath.toFile).mkString
+      Source.fromInputStream(response.inputStream).mkString shouldBe File(expectedFilePath).contentAsString
     }
   }
 


### PR DESCRIPTION
Fixes EASY-1945

#### When applied it will
* upgrade parent POM version
* remove self-contained dependency version tags
* fix issues caused by breaking changes of dependency updates
* change `lines.toList` to `linesIterator.toList` due to https://github.com/scala/bug/issues/11125
* remove ZipFile setFilenameCharset UTF8, since it is already the default value

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
