### PR TITLE
EASY-2785 Restore execute rights on easy-bag-store to all users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,22 +192,6 @@
                         <artifactId>rpm-maven-plugin</artifactId>
                         <configuration>
                             <group>Applications/Archiving</group>
-                            <mappings combine.children="append">
-                                <mapping>
-                                    <directory>/opt/${dans-provider-name}/${project.artifactId}/bin</directory>
-                                    <filemode>544</filemode>
-                                    <username>easy-bag-store</username>
-                                    <groupname>easy-bag-store</groupname>
-                                    <sources>
-                                        <source>
-                                            <location>src/main/assembly/dist/bin/${project.artifactId}</location>
-                                        </source>
-                                        <source>
-                                            <location>src/main/assembly/dist/bin/send-bag-store-report.sh</location>
-                                        </source>
-                                    </sources>
-                                </mapping>
-                            </mappings>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -38,7 +38,7 @@ bag-store.bag-dir-permissions=r-xr-xr-x
 #
 # Directory for staging bags for adding and retrieving from a bag store. This directory must be on
 # the same partition as the bag store. The reason for this is that the ADD action must be atomic.
-# To achieve this, each bag that is staged for addition to the bag store whill be moved. However,
+# To achieve this, each bag that is staged for addition to the bag store will be moved. However,
 # only a move within a partition is atomic.
 #
 bag-store.staging.base-dir=/srv/dans.knaw.nl/stage


### PR DESCRIPTION
This makes sure all users can execute `easy-bag-store`. Strangely, it seems setting the owner to `easy-bag-store` and the permissions to 544 was broken anyway in recent RPMs. It worked before, because in the 1.6.1 RPM the permissions *are* set according to the specs in the POM:

```
rpm -qlp --dump dans.knaw.nl-easy-bag-store-1.6.1-1.noarch.rpm | grep easy-bag-store/bin/easy-bag-store
/opt/bin/easy-bag-store 51 1589352668 0000000000000000000000000000000000000000000000000000000000000000 0120755 root root 0 0 0 /opt/dans.knaw.nl/easy-bag-store/bin/easy-bag-store
/opt/dans.knaw.nl/easy-bag-store/bin/easy-bag-store 515 1589352580 c590b762986f783e2b6a2c184d2d9796133e76454944202484f7af5ca5bcf1dd 0100544 easy-bag-store easy-bag-store 0 0 0 X
/opt/dans.knaw.nl/easy-bag-store/bin/easy-bag-store-1.6.1.jar 400618 1589352651 8cb4d494d16506e562d1a35dd74ec9bb7058c037d8263a6319fc152d0aa1f88a 0100744 root root 0 0 0 X
/opt/dans.knaw.nl/easy-bag-store/bin/easy-bag-store.jar 61 1589352668 0000000000000000000000000000000000000000000000000000000000000000 0120755 root root 0 0 0 /opt/dans.knaw.nl/easy-bag-store/bin/easy-bag-store-1.6.1.jar
```
Scroll to the right to find `...0100544 easy-bag-store easy-bag-store`. I am pretty sure the `0544` refers to the permissions of the file.

However, it is better not to rely on it working correctly by accident.


@DANS-KNAW/easy for review