### PR TITLE
EASY-2786 easy-bag-store export --bagid-list ids.txt -d outdir

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ SYNOPSIS
           list
         | add [-m,--move] [-u,--uuid <uuid>] <bag>
         | get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
-        | extract [-d,--directory <dir>] [-b, --bagid-list <file>]
+        | export [-d,--directory <dir>] [-b, --bagid-list <file>]
         | stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
         | enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] \ 
             [-i,--inactive] <bag-id>]

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ SYNOPSIS
           list
         | add [-m,--move] [-u,--uuid <uuid>] <bag>
         | get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
+        | extract [-d,--directory <dir>] [-b, --bagid-list <file>]
         | stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
         | enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] \ 
             [-i,--inactive] <bag-id>]

--- a/src/main/assembly/dist/bin/easy-bag-store
+++ b/src/main/assembly/dist/bin/easy-bag-store
@@ -4,9 +4,9 @@ BINPATH=`command readlink -f $0 2> /dev/null || command grealpath $0 2> /dev/nul
 APPHOME=`dirname \`dirname $BINPATH \``
 FHS_CONFIG=/etc/opt/dans.knaw.nl/easy-bag-store/
 
-if [ -f $HOME/logback.xml ]
+if [ -f $HOME/logback-easy-bag-store.xml ]
 then
-    LOGCONFIG=$HOME/logback.xml
+    LOGCONFIG=$HOME/logback-easy-bag-store.xml
 elif [ -d $FHS_CONFIG ]
 then
     LOGCONFIG=$FHS_CONFIG/logback.xml

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -15,8 +15,9 @@
  */
 package nl.knaw.dans.easy.bagstore.command
 
+import better.files.File
 import nl.knaw.dans.easy.bagstore.service.ServiceWiring
-import nl.knaw.dans.easy.bagstore.{ BaseDir, ItemId }
+import nl.knaw.dans.easy.bagstore.{ BaseDir, ItemId, NoSuchBagException }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 
@@ -24,7 +25,7 @@ import scala.annotation.tailrec
 import scala.io.StdIn
 import scala.language.{ postfixOps, reflectiveCalls }
 import scala.util.control.NonFatal
-import scala.util.{ Success, Try }
+import scala.util.{ Failure, Success, Try }
 
 object Command extends App with CommandLineOptionsComponent with ServiceWiring with DebugEnhancedLogging {
 
@@ -46,12 +47,20 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
       BagStore(baseDir)
         .add(cmd.bag(), cmd.uuid.toOption, skipStage = cmd.move())
         .map(bagId => s"Added bag with bag-id: $bagId to bag store: $baseDir")
+    case Some(cmd @ commandLine.extract) =>
+      val dirOut = cmd.outputDir()
+      File(cmd.items()).lines
+        .withFilter(!_.trim.isEmpty)
+        .withFilter(!_.trim.startsWith("#"))
+        .map(bagStores.extract(dirOut, bagStoreBaseDir))
+        .collectFirst { case Failure(e) => Failure(e) }
+        .getOrElse(Success("No fatal errors, see logging for details"))
     case Some(cmd @ commandLine.get) =>
       for {
         itemId <- ItemId.fromString(cmd.itemId())
         (path, store) <- bagStores.copyToDirectory(itemId, cmd.outputDir(), cmd.skipCompletion(), bagStoreBaseDir, cmd.forceInactive())
-        storeName = getStoreName(store)
-      } yield s"Retrieved item with item-id: $itemId to ${ path } from bag store: $storeName"
+        storeName = bagStores.getStoreName(store)
+      } yield s"Retrieved item with item-id: $itemId to $path from bag store: $storeName"
     case Some(cmd @ commandLine.stream) =>
       for {
         itemId <- ItemId.fromString(cmd.itemId())
@@ -69,7 +78,7 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
           val includeInactive = cmd.all() || cmd.inactive()
           bagStores.enumBags(includeActive, includeInactive, bagStoreBaseDir).map(_.foreach(println(_)))
         }
-        .map(_ => "Done enumerating" + bagStoreBaseDir.map(b => s" (limited to BagStore: ${ getStoreName(b) })").getOrElse(""))
+        .map(_ => "Done enumerating" + bagStoreBaseDir.map(b => s" (limited to BagStore: ${ bagStores.getStoreName(b) })").getOrElse(""))
     case Some(cmd @ commandLine.deactivate) =>
       for {
         itemId <- ItemId.fromString(cmd.bagId())
@@ -118,12 +127,6 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
     bagStores.storeShortnames
       .map { case (name, base) => s"- $name -> $base" }
       .mkString("\n")
-  }
-
-  private def getStoreName(p: BaseDir): String = {
-    bagStores.storeShortnames
-      .collectFirst { case (name, base) if base == p => name }
-      .getOrElse(p.toString)
   }
 
   @tailrec

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -47,12 +47,12 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
       BagStore(baseDir)
         .add(cmd.bag(), cmd.uuid.toOption, skipStage = cmd.move())
         .map(bagId => s"Added bag with bag-id: $bagId to bag store: $baseDir")
-    case Some(cmd @ commandLine.extract) =>
+    case Some(cmd @ commandLine.export) =>
       val dirOut = cmd.outputDir()
       File(cmd.items()).lines
         .withFilter(!_.trim.isEmpty)
         .withFilter(!_.trim.startsWith("#"))
-        .map(bagStores.extract(dirOut, bagStoreBaseDir))
+        .map(bagStores.exportBag(dirOut, bagStoreBaseDir))
         .collectFirst { case Failure(e) => Failure(e) }
         .getOrElse(Success("No fatal errors, see logging for details"))
     case Some(cmd @ commandLine.get) =>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -102,6 +102,18 @@ trait CommandLineOptionsComponent {
     }
     addSubcommand(add)
 
+    // export cause a name collision
+    val extract = new Subcommand("export") {
+      descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
+      val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
+        descr = "directory in which to put the exported bags (default = .)",
+        default = Some(Paths.get(".")))
+      val items: ScallopOption[Path] = opt[Path](name = "bagid-list", short = 'b', required = true,
+        descr = "newline-separated list of ids of the bags to export")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(extract)
+
     val get = new Subcommand("get") {
       descr("Retrieves an item by copying it to the specified directory (default: current directory).")
       val skipCompletion: ScallopOption[Boolean] = opt(name = "skip-completion",

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -103,7 +103,7 @@ trait CommandLineOptionsComponent {
     addSubcommand(add)
 
     // export cause a name collision
-    val extract = new Subcommand("export") {
+    val export = new Subcommand("export") {
       descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
       val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
         descr = "directory in which to put the exported bags (default = .)",
@@ -112,7 +112,7 @@ trait CommandLineOptionsComponent {
         descr = "newline-separated list of ids of the bags to export")
       footer(SUBCOMMAND_SEPARATOR)
     }
-    addSubcommand(extract)
+    addSubcommand(export)
 
     val get = new Subcommand("get") {
       descr("Retrieves an item by copying it to the specified directory (default: current directory).")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -47,6 +47,7 @@ trait CommandLineOptionsComponent {
          |${ _________ }| list
          |${ _________ }| add [-m,--move] [-u,--uuid <uuid>] <bag>
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
+         |${ _________ }| export [-d,--directory <dir>] [-b, --bagid-list <file>]
          |${ _________ }| stream [-f, --force-inactive] [--format zip|tar] <item-id>
          |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
@@ -102,18 +103,6 @@ trait CommandLineOptionsComponent {
     }
     addSubcommand(add)
 
-    // export cause a name collision
-    val export = new Subcommand("export") {
-      descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
-      val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
-        descr = "directory in which to put the exported bags (default = .)",
-        default = Some(Paths.get(".")))
-      val items: ScallopOption[Path] = opt[Path](name = "bagid-list", short = 'b', required = true,
-        descr = "newline-separated list of ids of the bags to export")
-      footer(SUBCOMMAND_SEPARATOR)
-    }
-    addSubcommand(export)
-
     val get = new Subcommand("get") {
       descr("Retrieves an item by copying it to the specified directory (default: current directory).")
       val skipCompletion: ScallopOption[Boolean] = opt(name = "skip-completion",
@@ -128,6 +117,17 @@ trait CommandLineOptionsComponent {
       footer(SUBCOMMAND_SEPARATOR)
     }
     addSubcommand(get)
+
+    val export = new Subcommand("export") {
+      descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
+      val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
+        descr = "directory in which to put the exported bags (default = .)",
+        default = Some(Paths.get(".")))
+      val items: ScallopOption[Path] = opt[Path](name = "bagid-list", short = 'b', required = true,
+        descr = "newline-separated list of ids of the bags to export")
+      footer(SUBCOMMAND_SEPARATOR)
+    }
+    addSubcommand(export)
 
     val stream = new Subcommand("stream") {
       descr("Retrieves an item by streaming it to the standard output")

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
 import nl.knaw.dans.easy.bagstore._
+import nl.knaw.dans.easy.bagstore.command.Command.{ BagPath, bagStoreBaseDir, bagStores, logger }
 import nl.knaw.dans.lib.error._
 import nl.knaw.dans.lib.logging.DebugEnhancedLogging
 import org.apache.commons.io.FileUtils
@@ -37,6 +38,25 @@ trait BagStoresComponent {
     def storeShortnames: Map[String, BaseDir]
 
     def getBaseDirByShortname(name: String): Option[BaseDir] = storeShortnames.get(name)
+
+    def getStoreName(p: Path): String = {
+      bagStores.storeShortnames
+        .collectFirst { case (name, base) if base == p => name }
+        .getOrElse(p.toString)
+    }
+
+    def extract(dirOut: BagPath, bagStoreBaseDir: Option[BaseDir])(inputLine: String): Try[Unit] = {
+      for {
+        itemId <- ItemId.fromString(inputLine.trim)
+        (path, store) <- bagStores.copyToDirectory(itemId, dirOut, fromStore = bagStoreBaseDir)
+        _ = logger.info(s"$inputLine: bag exported to $path from bag store: ${ bagStores.getStoreName(store) } }")
+      } yield ()
+    }.recover {
+      case e: IllegalArgumentException => logger.error(s"$inputLine: IllegalArgumentException ${ e.getMessage }")
+      case _: NoSuchBagException => logger.error(s"$inputLine: bag not found")
+      case t: Throwable => logger.error("Not expected exception",t)
+        Failure(t)
+    }
 
     def copyToDirectory(itemId: ItemId, output: Path, skipCompletion: Boolean = false, fromStore: Option[BaseDir] = None, forceInactive: Boolean = false): Try[(Path, BaseDir)] = {
       fromStore

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -19,6 +19,8 @@ import java.io.{ InputStream, OutputStream }
 import java.nio.file.{ Files, Path }
 import java.util.UUID
 
+import better.files.Dsl.SymbolicOperations
+import better.files.File
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.easy.bagstore.command.Command.{ BagPath, bagStoreBaseDir, bagStores, logger }
@@ -45,10 +47,11 @@ trait BagStoresComponent {
         .getOrElse(p.toString)
     }
 
-    def extract(dirOut: BagPath, bagStoreBaseDir: Option[BaseDir])(inputLine: String): Try[Unit] = {
+    def exportBag(dirOut: BagPath, bagStoreBaseDir: Option[BaseDir])(inputLine: String): Try[Unit] = {
       for {
         itemId <- ItemId.fromString(inputLine.trim)
-        (path, store) <- bagStores.copyToDirectory(itemId, dirOut, fromStore = bagStoreBaseDir)
+        bagIdDir <- Try { (File(dirOut) / itemId.toString).createDirectory() }
+        (path, store) <- bagStores.copyToDirectory(itemId, bagIdDir.path, fromStore = bagStoreBaseDir)
         _ = logger.info(s"$inputLine: bag exported to $path from bag store: ${ bagStores.getStoreName(store) } }")
       } yield ()
     }.recover {

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -17,6 +17,7 @@ package nl.knaw.dans.easy.bagstore.component
 
 import java.io.ByteArrayOutputStream
 import java.nio.file.{ Files, Paths }
+import java.util.UUID
 
 import nl.knaw.dans.easy.bagstore._
 import org.apache.commons.io.FileUtils
@@ -50,6 +51,26 @@ class BagStoresSpec extends TestSupportFixture
   private val testBagUnprunedC = testDir.resolve("basic-sequence-unpruned/c")
   private val testBagComplementary = testDir.resolve("valid-bag-complementary-manifests")
   private val testBagPrunedA = testDir.resolve("basic-sequence-pruned/a")
+
+  "extract" should "log success" in {
+    val output = testDir.resolve("pruned-output1")
+    inside(bagStore1.add(testBagPrunedA)) { case Success(result) =>
+      bagStores.extract(output, Some(bagStore1.baseDir))(result.uuid.toString) shouldBe a[Success[_]]
+      pathsEqual(testBagPrunedA, output.resolve("a")) shouldBe true
+    }
+    // TODO manually: examine logging
+  }
+
+  it should "log bag not found" in {
+    val output = testDir.resolve("pruned-output2")
+    bagStores.extract(output, Some(bagStore1.baseDir))(UUID.randomUUID().toString) shouldBe a[Success[_]]
+    // TODO manually: examine logging
+  }
+  it should "log IllegalArgumentException" in {
+    val output = testDir.resolve("pruned-output3")
+    bagStores.extract(output, Some(bagStore1.baseDir))("blablabla") shouldBe a[Success[_]]
+    // TODO manually: examine logging
+  }
 
   "get" should "return exactly the same Bag as was added" in {
     val output = testDir.resolve("pruned-output")

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.file.{ Files, Paths }
 import java.util.UUID
 
+import better.files.File
 import nl.knaw.dans.easy.bagstore._
 import org.apache.commons.io.FileUtils
 
@@ -52,24 +53,13 @@ class BagStoresSpec extends TestSupportFixture
   private val testBagComplementary = testDir.resolve("valid-bag-complementary-manifests")
   private val testBagPrunedA = testDir.resolve("basic-sequence-pruned/a")
 
-  "extract" should "log success" in {
-    val output = testDir.resolve("pruned-output1")
+  "exportBag" should "log success" in {
+    val output = testDir.resolve("completed-output1")
+    File(output).createDirectory()
     inside(bagStore1.add(testBagPrunedA)) { case Success(result) =>
-      bagStores.extract(output, Some(bagStore1.baseDir))(result.uuid.toString) shouldBe a[Success[_]]
-      pathsEqual(testBagPrunedA, output.resolve("a")) shouldBe true
+      bagStores.exportBag(output, Some(bagStore1.baseDir))(result.uuid.toString) shouldBe a[Success[_]]
+      pathsEqual(testBagPrunedA, output.resolve(result.toString).resolve("a")) shouldBe true
     }
-    // TODO manually: examine logging
-  }
-
-  it should "log bag not found" in {
-    val output = testDir.resolve("pruned-output2")
-    bagStores.extract(output, Some(bagStore1.baseDir))(UUID.randomUUID().toString) shouldBe a[Success[_]]
-    // TODO manually: examine logging
-  }
-  it should "log IllegalArgumentException" in {
-    val output = testDir.resolve("pruned-output3")
-    bagStores.extract(output, Some(bagStore1.baseDir))("blablabla") shouldBe a[Success[_]]
-    // TODO manually: examine logging
   }
 
   "get" should "return exactly the same Bag as was added" in {


### PR DESCRIPTION
Fixes EASY-2786

#### When applied it will...
* Continue the work of @jo-pol , replacing #107 
* Add the container directory named after the bag-id.
* Change the name back to `export`. The naming collision seems to be in only one place, where it can easily be worked around.
* Let `easy-bag-store` look in `$HOME/logback-easy-bag-store.xml` for custom logging config, instead of `$HOME/logback.xml` which would also be used by all other EASY tools, notably `easy-convert-bag-to-deposit`.

#### Where should the reviewer @DANS-KNAW/easy start?

