### PR TITLE
Removed the 'prune' step in add bag (attempt to fix problems with too many open files)

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -232,8 +232,6 @@ trait BagStoreComponent {
           _ = debug(s"refbags tempfile: $maybeRefbags")
           valid <- fileSystem.isVirtuallyValid(path).recover { case _: BagReaderException => Left("Could not read bag") }
           _ <- valid.fold(msg => Failure(InvalidBagException(bagId, msg)), _ => Success(()))
-          _ <- maybeRefbags.map(pruneWithReferenceBags(path)).getOrElse(Success(()))
-          _ = debug("bag succesfully pruned")
           container <- fileSystem.toContainer(bagId)
           _ = Files.createDirectories(container)
           _ <- fileSystem.makePathAndParentsInBagStoreGroupWritable(container)

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/StoresServletSpec.scala
@@ -402,30 +402,6 @@ class StoresServletSpec extends TestSupportFixture
     }
   }
 
-  it should "store and prune multiple revisions of a bagsequence" in {
-    val uuid1 = "11111111-1111-1111-1111-111111111111"
-    val uuid2 = "11111111-1111-1111-1111-111111111112"
-    val uuid3 = "11111111-1111-1111-1111-111111111113"
-
-    putBag(uuid1, testBagUnprunedA)
-    putBag(uuid2, testBagUnprunedB)
-    putBag(uuid3, testBagUnprunedC)
-
-    val pruned = Paths.get("src/test/resources/bags/basic-sequence-pruned")
-
-    pathsEqual(pruned.resolve("a"), store1.resolve("11/111111111111111111111111111111/a")) shouldBe true
-
-    pathsEqual(pruned.resolve("b"), store1.resolve("11/111111111111111111111111111112/b"), "fetch.txt", "tagmanifest-md5.txt") shouldBe true
-    // BagProcessing.complete causes the order in b/tagmanifest-md5.txt to change...
-    Source.fromFile(pruned.resolve("b/tagmanifest-md5.txt").toFile).getLines().toList should
-      contain theSameElementsAs Source.fromFile(store1.resolve("11/111111111111111111111111111112/b/tagmanifest-md5.txt").toFile).getLines().toList
-
-    pathsEqual(pruned.resolve("c"), store1.resolve("11/111111111111111111111111111113/c"), "fetch.txt", "tagmanifest-md5.txt") shouldBe true
-    // BagProcessing.complete causes the order in c/tagmanifest-md5.txt to change...
-    Source.fromFile(pruned.resolve("c/tagmanifest-md5.txt").toFile).getLines().toList should
-      contain theSameElementsAs Source.fromFile(store1.resolve("11/111111111111111111111111111113/c/tagmanifest-md5.txt").toFile).getLines().toList
-  }
-
   it should "make an identity with get/:bagstore/bags/:uuid" in {
     def retrieveBag(uuid: String, bagName: String): Unit = {
       get(s"/store1/bags/$uuid", params = Map.empty, headers = Map("Accept" -> "application/zip")) {
@@ -542,16 +518,6 @@ class StoresServletSpec extends TestSupportFixture
     put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), headers = basicAuthenticationAndZipContentType) {
       status shouldBe 400
       body shouldBe InvalidBagException(bagId, "the bag contains an empty refbags.txt").getMessage
-    }
-  }
-
-  it should "fail when an invalid refbags.txt is provided" in {
-    val content = "invalid content"
-    createZipWithInvalidOrEmptyRefBag(content)
-    val uuid = "11111111-1121-1111-1111-111111111111"
-    put(s"/store1/bags/$uuid", body = Files.readAllBytes(testBagUnprunedEmptyRefBag), headers = basicAuthenticationAndZipContentType) {
-      status shouldBe 400
-      body shouldBe s"String '$content' is not a UUID"
     }
   }
 


### PR DESCRIPTION
NO JIRA

#### When applied it will...
* Remove the prune step to try and avoid opening too many files when processing large deposits.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
