### PR TITLE
DD-591: Extend easy-bag-store enum with 'from-date' option

### DIFF
--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import nl.knaw.dans.lib.string._
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
-import nl.knaw.dans.easy.bagstore.{ ArchiveStreamType, ConfigurationComponent }
+import nl.knaw.dans.easy.bagstore.{ ArchiveStreamType, ConfigurationComponent, FromDateException }
 import org.rogach.scallop.{ ScallopConf, ScallopOption, Subcommand, ValueConverter, singleArgConverter, stringConverter }
 
 trait CommandLineOptionsComponent {
@@ -49,7 +49,7 @@ trait CommandLineOptionsComponent {
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
          |${ _________ }| export [-d,--directory <dir>] [-b, --bagid-list <file>]
          |${ _________ }| stream [-f, --force-inactive] [--format zip|tar] <item-id>
-         |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>]
+         |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>] [-d, --from-date]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
          |${ _________ }| deactivate <bag-id>
          |${ _________ }| reactivate <bag-id>
@@ -151,6 +151,8 @@ trait CommandLineOptionsComponent {
         descr = "enumerate only regular files, not directories")
       val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
         descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
+      val fromDate: ScallopOption[String] = opt(name = "from-date", short = 'd',
+        descr = "Enumerate only bags that are created after this time. Format is yyyy-MM-ddTHH:mm:ss (e.g. 2021-08-25T10:25:10")
       val bagId: ScallopOption[String] = trailArg[String](name = "<bagId>",
         descr = "bag of which to enumerate the Files",
         required = false)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoreComponent.scala
@@ -17,8 +17,7 @@ package nl.knaw.dans.easy.bagstore.component
 
 import java.io.OutputStream
 import java.nio.file.{ Files, Path, Paths }
-import java.util.UUID
-
+import java.util.{ Date, UUID }
 import nl.knaw.dans.easy.bagstore.ArchiveStreamType.ArchiveStreamType
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error._
@@ -37,10 +36,10 @@ trait BagStoreComponent {
 
     implicit val baseDir: BaseDir
 
-    def enumBags(includeActive: Boolean = true, includeInactive: Boolean = false): Try[Seq[BagId]] = Try {
+    def enumBags(includeActive: Boolean = true, includeInactive: Boolean = false, date: Date): Try[Seq[BagId]] = Try {
       trace(includeActive, includeInactive)
 
-      managed(fileSystem.walkStore)
+      managed(fileSystem.walkStore(date))
         .acquireAndGet(_.iterator().asScala.toStream
           // TODO: is there a better way to fail fast than using .get?
           .map(p => fileSystem.fromLocation(p).flatMap(_.toBagId).get)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/FileSystemComponent.scala
@@ -19,7 +19,7 @@ import java.net.URI
 import java.nio.file._
 import java.nio.file.attribute.{ BasicFileAttributes, PosixFilePermission }
 import java.util.stream.{ Stream => JStream }
-import java.util.{ UUID, Set => JSet }
+import java.util.{ Date, UUID, Set => JSet }
 
 import nl.knaw.dans.easy.bagstore._
 import nl.knaw.dans.lib.error._
@@ -49,9 +49,10 @@ trait FileSystemComponent extends DebugEnhancedLogging {
     /**
      * @return Lazily populated JStream with bags in this base directory
      */
-    def walkStore(implicit baseDir: BaseDir): JStream[BagPath] = {
+    def walkStore(date: Date)(implicit baseDir: BaseDir): JStream[BagPath] = {
       Files.walk(baseDir, uuidPathComponentSizes.size, FileVisitOption.FOLLOW_LINKS)
         .filter(baseDir.relativize(_).getNameCount == uuidPathComponentSizes.size)
+        .filter(Files.getLastModifiedTime(_).toMillis > date.getTime)
     }
 
     def fromLocation(path: Path)(implicit baseDir: BaseDir): Try[ItemId] = {

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/package.scala
@@ -53,6 +53,7 @@ package object bagstore {
   case class InvalidBagException(bagId: BagId, msg: String) extends Exception(s"Bag $bagId is not a valid bag: $msg")
   case class NoRegularFileException(itemId: ItemId) extends Exception(s"Item $itemId is not a regular file.")
   case class UnsupportedMediaTypeException(givenType: String, acceptedType: String) extends Exception(s"media type $givenType is not supported by this API. Supported types are '$acceptedType'")
+  case class FromDateException(date: String) extends Exception(s"from-date $date is not a valid date, the correct format is yyyy-MM-ddTHH:mm:ss (e.g. 2021-08-25T10:25:10)")
 
   type BaseDir = Path
 

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/component/BagStoresSpec.scala
@@ -17,7 +17,7 @@ package nl.knaw.dans.easy.bagstore.component
 
 import java.io.ByteArrayOutputStream
 import java.nio.file.{ Files, Paths }
-import java.util.UUID
+import java.text.SimpleDateFormat
 
 import better.files.File
 import nl.knaw.dans.easy.bagstore._
@@ -144,6 +144,18 @@ class BagStoresSpec extends TestSupportFixture
         inside(bagStore1.add(testBagUnprunedC)) { case Success(cis) =>
           inside(bagStores.enumBags().map(_.toList)) {
             case Success(bagIds) => bagIds should (have size 3 and contain only(ais, bis, cis))
+          }
+        }
+      }
+    }
+  }
+
+  it should "return no BagIds when the from-date is after the creation time of these bags" in {
+    inside(bagStore1.add(testBagUnprunedA)) { case Success(ais) =>
+      inside(bagStore1.add(testBagUnprunedB)) { case Success(bis) =>
+        inside(bagStore1.add(testBagUnprunedC)) { case Success(cis) =>
+          inside(bagStores.enumBags(true, false, None, Option(new SimpleDateFormat("yyyy-MM-dd").parse("2025-12-31"))).map(_.toList)) {
+            case Success(bagIds) => bagIds should (have size 0)
           }
         }
       }


### PR DESCRIPTION
Fixes DD-591

#### When applied it will...
* add a new optional parameter `from-date` to the `enum` subcommand
* only bags that are created after this time will be enumerated

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
