### PR TITLE
DD-808: force-inactive for export

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@ Fixes EASY-
 * 
 * [ ] manual check of CLI in index.md (the usual ReadmeSpec is not figured out for the cake pattern)
 
-    mvn clean install -DskipTests
-    run.sh --help > data/help.txt`
+      mvn clean install -DskipTests
+      run.sh --help > data/help.txt`
 
   compare `data/help.txt` with `docs/index.md`
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,14 @@ Fixes EASY-
 #### Where should the reviewer @DANS-KNAW/easy start?
 
 #### How should this be manually tested?
+* 
+* 
+* [ ] manual check of CLI in index.md (the usual ReadmeSpec is not figured out for the cake pattern)
+
+    mvn clean install -DskipTests
+    run.sh --help > data/help.txt`
+
+  compare `data/help.txt` with `docs/index.md`
 
 #### Related pull requests on github
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,8 +100,8 @@ ARGUMENTS
     
     Subcommand: export - Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.
       -b, --bagid-list  <arg>   newline-separated list of ids of the bags to export
-      -d, --directory  <arg>    directory in which to put the exported bags
-                                (default = .)
+      -d, --directory  <arg>    existing empty directory in which to put the
+                                exported bags (default = .)
       -f, --force-inactive      force retrieval of an inactive item (by default
                                 inactive items are not retrieved)
       -h, --help                Show help message
@@ -120,8 +120,9 @@ ARGUMENTS
     Subcommand: enum - Enumerates bags or Files
       -a, --all                   enumerate all bags, including inactive ones
       -e, --exclude-directories   enumerate only regular files, not directories
-      -f, --force-inactive        force retrieval of an inactive item (by default
-                                  inactive items are not retrieved)
+      -f, --force-inactive        force enumeration of files of an inactive bag (by
+                                  default the files of an inactive bag are not
+                                  enumerated)
       -d, --from-date  <arg>      Enumerate only bags that are created after this
                                   time. Format is yyyy-MM-ddTHH:mm:ss (e.g.
                                   2021-08-25T10:25:10)

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,9 @@ SYNOPSIS
           list
         | add [-m,--move] [-u,--uuid <uuid>] <bag>
         | get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
-        | export [-d,--directory <dir>] [-b, --bagid-list <file>]
-        | stream [-f, --force-inactive] [-f,--format zip|tar] <item-id>
-        | enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] \ 
+        | export [-f, --force-inactive] [-d,--directory <dir>] [-b, --bagid-list <file>]
+        | stream [-f, --force-inactive] [--format zip|tar] <item-id>
+        | enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] [-d, --from-date] \ 
             [-i,--inactive] <bag-id>]
         | locate [-f,--file-data-location] <item-id>
         | deactivate <bag-id>
@@ -68,20 +68,20 @@ ARGUMENTS
 
       -b, --base-dir  <arg>     bag store base-dir to use
       -s, --store-name  <arg>   Configured store to use
-          --help                Show help message
-          --version             Show version of this program
+      -h, --help                Show help message
+      -v, --version             Show version of this program
     
     Subcommand: list - Lists the bag stores for which a shortname has been defined. These are the bag stores
     that are also accessible through the HTTP interface.
     
-          --help   Show help message
+      -h, --help   Show help message
     ---
     
     Subcommand: add - Adds a bag to the bag-store
       -m, --move          move (rather than copy) the bag when adding it to the bag
                           store
       -u, --uuid  <arg>   UUID to use as bag-id for the bag
-          --help          Show help message
+      -h, --help          Show help message
     
      trailing arguments:
       bag (required)   the (unserialized) bag to add
@@ -89,16 +89,29 @@ ARGUMENTS
     
     Subcommand: get - Retrieves an item by copying it to the specified directory (default: current directory).
       -d, --directory  <arg>   directory in which to put the item (default = .)
+      -f, --force-inactive     force retrieval of an inactive item (by default
+                               inactive items are not retrieved)
       -s, --skip-completion    do not complete an incomplete bag
-          --help               Show help message
+      -h, --help               Show help message
     
      trailing arguments:
       item-id (required)   item-id of the item to copy
     ---
     
+    Subcommand: export - Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.
+      -b, --bagid-list  <arg>   newline-separated list of ids of the bags to export
+      -d, --directory  <arg>    directory in which to put the exported bags
+                                (default = .)
+      -f, --force-inactive      force retrieval of an inactive item (by default
+                                inactive items are not retrieved)
+      -h, --help                Show help message
+    ---
+    
     Subcommand: stream - Retrieves an item by streaming it to the standard output
-          --format  <arg>   stream item packaged in this format (tar|zip)
-          --help            Show help message
+      -f, --force-inactive   force retrieval of an inactive item (by default
+                             inactive items are not retrieved)
+      --format  <arg>        stream item packaged in this format (tar|zip)
+      -h, --help             Show help message
     
      trailing arguments:
       item-id (required)   item-id of the item to stream
@@ -107,8 +120,13 @@ ARGUMENTS
     Subcommand: enum - Enumerates bags or Files
       -a, --all                   enumerate all bags, including inactive ones
       -e, --exclude-directories   enumerate only regular files, not directories
-      -d, --inactive              only enumerate inactive bags
-          --help                  Show help message
+      -f, --force-inactive        force retrieval of an inactive item (by default
+                                  inactive items are not retrieved)
+      -d, --from-date  <arg>      Enumerate only bags that are created after this
+                                  time. Format is yyyy-MM-ddTHH:mm:ss (e.g.
+                                  2021-08-25T10:25:10)
+      -i, --inactive              only enumerate inactive bags
+      -h, --help                  Show help message
     
      trailing arguments:
       <bagId> (not required)   bag of which to enumerate the Files
@@ -116,28 +134,30 @@ ARGUMENTS
     
     Subcommand: locate - Locates the item with <item-id> on the file system
       -f, --file-data-location   resolve to file-data-location
-          --help                 Show help message
+      -h, --help                 Show help message
     
      trailing arguments:
       <item-id> (required)   the item to locate
     ---
     
     Subcommand: deactivate - Marks a bag as inactive
-          --help   Show help message
+      -h, --help   Show help message
     
      trailing arguments:
       <bag-id> (required)   bag to mark as inactive
     ---
     
     Subcommand: reactivate - Reactivates an inactive bag
-          --help   Show help message
+      -h, --help   Show help message
     
      trailing arguments:
       <bag-id> (required)   inactive bag to re-activate
     ---
     
-    Subcommand: prune - Removes Files from bag, that are already found in reference bags, replacing them with fetch.txt references
-          --help   Show help message
+    Subcommand: prune - Removes Files from bag, that are already found in reference bags, replacing them with
+      fetch.txt references.
+    
+      -h, --help   Show help message
     
      trailing arguments:
       <bag-dir> (required)         bag directory to prune
@@ -146,22 +166,22 @@ ARGUMENTS
     ---
     
     Subcommand: complete - Resolves fetch.txt references from the bag store and copies them into <bag-dir>
-      -k, --keep-fetchtxt   do not delete fetch.txt, if present
-          --help            Show help message
+      -f, --keep-fetchtxt   do not delete fetch.txt, if present
+      -h, --help            Show help message
     
      trailing arguments:
       <bag-dir> (required)   bag directory to complete
     ---
     
     Subcommand: validate - Checks that <bag-dir> is a virtually-valid bag
-          --help   Show help message
+      -h, --help   Show help message
     
      trailing arguments:
       <bag-dir> (required)   bag directory to validate
     ---
-    
+      
     Subcommand: run-service - Starts the EASY Bag Store as a daemon that services HTTP requests
-          --help   Show help message
+      -h, --help   Show help message
     ---
 
 

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/Command.scala
@@ -53,9 +53,9 @@ object Command extends App with CommandLineOptionsComponent with ServiceWiring w
     case Some(cmd @ commandLine.export) =>
       val dirOut = cmd.outputDir()
       File(cmd.items()).lines
-        .withFilter(!_.trim.isEmpty)
+        .withFilter(_.trim.nonEmpty)
         .withFilter(!_.trim.startsWith("#"))
-        .map(bagStores.exportBag(dirOut, bagStoreBaseDir))
+        .map(bagStores.exportBag(dirOut, bagStoreBaseDir, forceInactive = cmd.forceInactive()))
         .collectFirst { case Failure(e) => Failure(e) }
         .getOrElse(Success("No fatal errors, see logging for details"))
     case Some(cmd @ commandLine.get) =>

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -31,6 +31,7 @@ trait CommandLineOptionsComponent {
   class CommandLineOptions(args: Array[String]) extends ScallopConf(args) {
     appendDefaultToDescription = true
     editBuilder(_.setHelpWidth(100))
+    private val forceInactiveDescription = "force retrieval of an inactive item (by default inactive items are not retrieved)"
 
     printedName = "easy-bag-store"
     private val _________ = " " * (printedName.length + 2)
@@ -47,9 +48,9 @@ trait CommandLineOptionsComponent {
          |${ _________ }| list
          |${ _________ }| add [-m,--move] [-u,--uuid <uuid>] <bag>
          |${ _________ }| get [-d,--directory <dir>] [-f, --force-inactive] [-s,--skip-completion] <item-id>
-         |${ _________ }| export [-d,--directory <dir>] [-b, --bagid-list <file>]
+         |${ _________ }| export [-f, --force-inactive] [-d,--directory <dir>] [-b, --bagid-list <file>]
          |${ _________ }| stream [-f, --force-inactive] [--format zip|tar] <item-id>
-         |${ _________ }| enum [[-a,--all] [-e,--exclude-directories] [-i,--inactive] [-f, --force-inactive] <bag-id>] [-d, --from-date]
+         |${ _________ }| enum [[-a,--all] [-f, --force-inactive] [-e,--exclude-directories] [-d, --from-date] [-i,--inactive] <bag-id>]
          |${ _________ }| locate [-f,--file-data-location] <item-id>
          |${ _________ }| deactivate <bag-id>
          |${ _________ }| reactivate <bag-id>
@@ -107,8 +108,7 @@ trait CommandLineOptionsComponent {
       descr("Retrieves an item by copying it to the specified directory (default: current directory).")
       val skipCompletion: ScallopOption[Boolean] = opt(name = "skip-completion",
         descr = "do not complete an incomplete bag")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
-        descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
       val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
         descr = "directory in which to put the item",
         default = Some(Paths.get(".")))
@@ -120,8 +120,9 @@ trait CommandLineOptionsComponent {
 
     val export = new Subcommand("export") {
       descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
       val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
-        descr = "directory in which to put the exported bags (default = .)",
+        descr = "directory in which to put the exported bags",
         default = Some(Paths.get(".")))
       val items: ScallopOption[Path] = opt[Path](name = "bagid-list", short = 'b', required = true,
         descr = "newline-separated list of ids of the bags to export")
@@ -133,8 +134,7 @@ trait CommandLineOptionsComponent {
       descr("Retrieves an item by streaming it to the standard output")
       val format: ScallopOption[ArchiveStreamType] = opt(name = "format", noshort = true,
         descr = "stream item packaged in this format (tar|zip)")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
-        descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
       val itemId: ScallopOption[String] = trailArg[String](name = "item-id",
         descr = "item-id of the item to stream")
       footer(SUBCOMMAND_SEPARATOR)
@@ -149,10 +149,9 @@ trait CommandLineOptionsComponent {
         descr = "enumerate all bags, including inactive ones")
       val excludeDirectories: ScallopOption[Boolean] = opt(name = "exclude-directories", short = 'e',
         descr = "enumerate only regular files, not directories")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
-        descr = "force retrieval of an inactive item (by default inactive items are not retrieved)")
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
       val fromDate: ScallopOption[String] = opt(name = "from-date", short = 'd',
-        descr = "Enumerate only bags that are created after this time. Format is yyyy-MM-ddTHH:mm:ss (e.g. 2021-08-25T10:25:10")
+        descr = "Enumerate only bags that are created after this time. Format is yyyy-MM-ddTHH:mm:ss (e.g. 2021-08-25T10:25:10)")
       val bagId: ScallopOption[String] = trailArg[String](name = "<bagId>",
         descr = "bag of which to enumerate the Files",
         required = false)

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/command/CommandLineOptionsComponent.scala
@@ -122,7 +122,7 @@ trait CommandLineOptionsComponent {
       descr("Exports bags to directories named with the bag-id of the bag. The bags are always valid, so virtually valid bags in the store are first completed.")
       val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
       val outputDir: ScallopOption[Path] = opt(name = "directory", short = 'd',
-        descr = "directory in which to put the exported bags",
+        descr = "existing empty directory in which to put the exported bags",
         default = Some(Paths.get(".")))
       val items: ScallopOption[Path] = opt[Path](name = "bagid-list", short = 'b', required = true,
         descr = "newline-separated list of ids of the bags to export")
@@ -149,7 +149,8 @@ trait CommandLineOptionsComponent {
         descr = "enumerate all bags, including inactive ones")
       val excludeDirectories: ScallopOption[Boolean] = opt(name = "exclude-directories", short = 'e',
         descr = "enumerate only regular files, not directories")
-      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f', descr = forceInactiveDescription)
+      val forceInactive: ScallopOption[Boolean] = opt(name = "force-inactive", short = 'f',
+        descr = "force enumeration of files of an inactive bag (by default the files of an inactive bag are not enumerated)")
       val fromDate: ScallopOption[String] = opt(name = "from-date", short = 'd',
         descr = "Enumerate only bags that are created after this time. Format is yyyy-MM-ddTHH:mm:ss (e.g. 2021-08-25T10:25:10)")
       val bagId: ScallopOption[String] = trailArg[String](name = "<bagId>",

--- a/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
+++ b/src/main/scala/nl.knaw.dans.easy.bagstore/component/BagStoresComponent.scala
@@ -47,11 +47,11 @@ trait BagStoresComponent {
         .getOrElse(p.toString)
     }
 
-    def exportBag(dirOut: BagPath, bagStoreBaseDir: Option[BaseDir])(inputLine: String): Try[Unit] = {
+    def exportBag(dirOut: BagPath, bagStoreBaseDir: Option[BaseDir], forceInactive: Boolean = false)(inputLine: String): Try[Unit] = {
       for {
         itemId <- ItemId.fromString(inputLine.trim)
         bagIdDir <- Try { (File(dirOut) / itemId.toString).createDirectory() }
-        (path, store) <- bagStores.copyToDirectory(itemId, bagIdDir.path, fromStore = bagStoreBaseDir)
+        (path, store) <- bagStores.copyToDirectory(itemId, bagIdDir.path, fromStore = bagStoreBaseDir, forceInactive = forceInactive)
         _ = logger.info(s"$inputLine: bag exported to $path from bag store: ${ bagStores.getStoreName(store) } }")
       } yield ()
     }.recover {


### PR DESCRIPTION
Fixes DD-808: force-inactive for export

#### When applied it will...
* have `index.md` synced with the actual CLI
* [x] manually check synopsis with actual commands
* a new option --force-inactive for sub-command `export`
* [x] unit tests for the new functionality
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?
* [x] similar steps as in the new unit test
  * rename `data/bag-store1/01/000000000000000000000000000003/bag-revision-3` to ...`\.bag-revision-3`
  * put `01000000000000000000000000000003`in the `--bagid-list` file
  * execute `run.sh export ...` without and with `-f`
* [x] manual check of CLI in index.md (the usual ReadmeSpec is not figured out for the cake pattern)

      mvn clean install -DskipTests
      run.sh --help > data/help.txt`

  compare `data/help.txt` with `docs/index.md`
#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
