### PR TITLE
DD-950: add forceInactive param to file request

### DIFF
--- a/docs/api/api.yml
+++ b/docs/api/api.yml
@@ -60,6 +60,7 @@ paths:
         potentially become very long, this request also supports two optional parameters to retrieve
         only part of the list.
       parameters:
+        - $ref: '#/components/parameters/State'
         - $ref: '#/components/parameters/Offset'
         - $ref: '#/components/parameters/Limit'
       responses:
@@ -110,6 +111,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Uuid'
         - $ref: '#/components/parameters/FilePath'
+        - $ref: '#/components/parameters/ForceInactive'
       responses:
         200:
           $ref: '#/components/responses/GetItemFromBagOk'
@@ -272,6 +274,20 @@ paths:
 components:
 
   parameters:
+    State:
+      in: query
+      name: state
+      schema:
+        type: string
+      required: false
+      description: "Either 'all' or 'inactive'. Anything else or not specified implies active bags only."
+    ForceInactive:
+      in: query
+      name: forceInactive
+      schema:
+        type: boolean
+      required: false
+      description: "Whether to return files of a hidden bag."
     Offset:
       in: query
       name: offset

--- a/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
+++ b/src/test/scala/nl.knaw.dans.easy.bagstore/server/BagsServletSpec.scala
@@ -244,6 +244,20 @@ class BagsServletSpec extends TestSupportFixture
     }
   }
 
+  it should "retrieve an item within an inactive/hidden bag is requested with forceInactive" in {
+    val bagID = "01000000-0000-0000-0000-000000000001"
+    val itemId = bagID + "/bag-info.txt"
+    bagStore1.deactivate(BagId(UUID.fromString(bagID))) shouldBe a[Success[_]]
+    get(s"/$itemId?forceInactive") {
+      status shouldBe 200
+      body shouldBe """Payload-Oxum: 72.6
+                      |Bagging-Date: 2016-06-07
+                      |Bag-Size: 0.6 KB
+                      |Created: 2017-01-16T14:35:00.888+01:00
+                      |""".stripMargin
+    }
+  }
+
   // this calls enumFiles
   it should " fail when done on an inactive/ hidden bag when headers text/plain is provided" in {
     val bagID = "01000000-0000-0000-0000-000000000001"


### PR DESCRIPTION
Fixes DD-950: add forceInactive param to file request

#### When applied it will...
* have updated swagger documentation
* an optional param forceRequest on retrieving files
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

* [x] manual check of CLI in index.md (the usual ReadmeSpec is not figured out for the cake pattern)

      mvn clean install
      run.sh --help > data/help.txt`

  compare `data/help.txt` with `docs/index.md`

With deasy under easy-dtap running
  * in the root of the local easy-sword2-dans-examples repo:

        ./run.sh Simple https://deasy.dans.knaw.nl/sword2/collection/1 user001 user001 src/main/resources/agreement-flow/valid/audiences

* deploy: in the root of `easy-dtap` execute `deploy.py --easy-role easy-bag-store`
* [x] on deasy `sudo su easy-bag-store` and  `/opt/bin/easy-bag-store deactivate` with a UUID returned by `easy-bag-store enum`
* [x] mimic new unit test with curl

       curl 'http://localhost:20110/bags/a38fcabd-f98e-43c9-bc97-a43fea6c73d3/bagit.txt?forceInactive'

#### Related pull requests on github

repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
